### PR TITLE
[Feature] added role protection to 'la rioja' reports

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja-routing.module.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja-routing.module.ts
@@ -1,14 +1,19 @@
 import { RouterModule, Routes } from "@angular/router";
 import { ReportesLariojaComponent } from "./reportes-larioja.component";
 import { NgModule } from "@angular/core";
+import { RoleGuard } from "@core/guards/RoleGuard";
+import { ERole } from "@api-rest/api-model";
 
 const routes: Routes = [
     {
         path: '',
         children: [
-            {path: '', component: ReportesLariojaComponent},
-
-        ]
+            {path: '', component: ReportesLariojaComponent}
+        ],
+        canActivate: [RoleGuard],
+        data: {
+            allowedRoles: [ERole.ADMINISTRADOR_INSTITUCIONAL_BACKOFFICE, ERole.PERSONAL_DE_ESTADISTICA]
+        }
     },
 ];
 


### PR DESCRIPTION
## Descripción del cambio.

Se agregó protección de roles a las rutas del módulo **'Reportes provinciales'**, garantizando que solo los usuarios con roles específicos puedan acceder a esta ruta.

### Roles con acceso.

- ADMINISTRADOR_INSTITUCIONAL_BACKOFFICE.
- PERSONAL_DE_ESTADISTICA.

## Issues relacionadas.

Closes: #9