### PR TITLE
Modificación de fechas en Reportes Provinciales

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/generalreports/service/impl/GeneralReportExcelServiceImpl.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/generalreports/service/impl/GeneralReportExcelServiceImpl.java
@@ -11,6 +11,7 @@ import net.pladema.generalreports.repository.ComplementaryStudiesConsultationDet
 import net.pladema.generalreports.repository.DiabeticHypertensionConsultationDetail;
 import net.pladema.generalreports.repository.EmergencyConsultationDetail;
 import net.pladema.generalreports.service.GeneralReportExcelService;
+import net.pladema.reportformat.DateFormat;
 
 import org.springframework.stereotype.Service;
 
@@ -27,6 +28,11 @@ public class GeneralReportExcelServiceImpl implements GeneralReportExcelService 
 	private ICellStyle titleStyle;
 	private ICellStyle fieldStyle;
 	private ICellStyle subTitleStyle;
+	private final DateFormat reformatdate;
+
+	public GeneralReportExcelServiceImpl(DateFormat reformatdate) {
+		this.reformatdate = reformatdate;
+	}
 
 	@Override
 	public IWorkbook buildExcelEmergency(String title, String[] headers, List<EmergencyConsultationDetail> result) {
@@ -232,7 +238,7 @@ public class GeneralReportExcelServiceImpl implements GeneralReportExcelService 
 		cell5.setCellStyle(style);
 
 		ICell cell6 = row.createCell(rowNumber.getAndIncrement());
-		cell6.setCellValue(content.getAttentionDate());
+		cell6.setCellValue(reformatdate.ReformatDate(content.getAttentionDate()));
 		cell6.setCellStyle(style);
 
 		ICell cell7 = row.createCell(rowNumber.getAndIncrement());
@@ -305,7 +311,7 @@ public class GeneralReportExcelServiceImpl implements GeneralReportExcelService 
 		cell1.setCellStyle(style);
 
 		ICell cell2 = row.createCell(rowNumber.getAndIncrement());
-		cell2.setCellValue(content.getAttentionDate());
+		cell2.setCellValue(reformatdate.ReformatDateFour(content.getAttentionDate()));
 		cell2.setCellStyle(style);
 
 		ICell cell3 = row.createCell(rowNumber.getAndIncrement());
@@ -350,7 +356,7 @@ public class GeneralReportExcelServiceImpl implements GeneralReportExcelService 
 		cell.setCellStyle(style);
 
 		ICell cell1 = row.createCell(rowNumber.getAndIncrement());
-		cell1.setCellValue(content.getDate());
+		cell1.setCellValue(reformatdate.ReformatDateTwo(content.getDate()));
 		cell1.setCellStyle(style);
 
 		ICell cell2 = row.createCell(rowNumber.getAndIncrement());
@@ -410,7 +416,7 @@ public class GeneralReportExcelServiceImpl implements GeneralReportExcelService 
 		cell17.setCellStyle(style);
 
 		ICell cell19 = row.createCell(rowNumber.getAndIncrement());
-		cell19.setCellValue(content.getDateOfIssue());
+		cell19.setCellValue(reformatdate.ReformatDateFour(content.getDateOfIssue()));
 		cell19.setCellStyle(style);
 
 		ICell cell20 = row.createCell(rowNumber.getAndIncrement());

--- a/back-end/hospital-api/src/main/java/net/pladema/nursingreports/service/impl/NursingReportExcelServiceImpl.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/nursingreports/service/impl/NursingReportExcelServiceImpl.java
@@ -13,6 +13,7 @@ import net.pladema.nursingreports.repository.NursingOutpatientConsultationDetail
 import net.pladema.nursingreports.repository.NursingProceduresConsultationDetail;
 import net.pladema.nursingreports.repository.NursingVaccineConsultationDetail;
 import net.pladema.nursingreports.service.NursingReportExcelService;
+import net.pladema.reportformat.DateFormat;
 
 import org.springframework.stereotype.Service;
 
@@ -29,6 +30,12 @@ public class NursingReportExcelServiceImpl implements NursingReportExcelService 
 	private ICellStyle titleStyle;
 	private ICellStyle fieldStyle;
 	private ICellStyle subTitleStyle;
+	private final DateFormat reformatdate;
+
+	public NursingReportExcelServiceImpl(DateFormat reformatdate) {
+		this.reformatdate = reformatdate;
+	}
+
 
 	@Override
 	public IWorkbook buildExcelNursingEmergency(String title, String[] headers, List<NursingEmergencyConsultationDetail> result) {
@@ -446,7 +453,7 @@ public class NursingReportExcelServiceImpl implements NursingReportExcelService 
 		cell3.setCellStyle(style);
 
 		ICell cell4 = row.createCell(rowNumber.getAndIncrement());
-		cell4.setCellValue(content.getAttentionDate());
+		cell4.setCellValue(reformatdate.ReformatDateThree(content.getAttentionDate()));
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
@@ -478,7 +485,7 @@ public class NursingReportExcelServiceImpl implements NursingReportExcelService 
 		cell11.setCellStyle(style);
 
 		ICell cell12 = row.createCell(rowNumber.getAndIncrement());
-		cell12.setCellValue(content.getBirthDate());
+		cell12.setCellValue(reformatdate.ReformatDateFive(content.getBirthDate()));
 		cell12.setCellStyle(style);
 
 		ICell cell13 = row.createCell(rowNumber.getAndIncrement());
@@ -652,7 +659,7 @@ public class NursingReportExcelServiceImpl implements NursingReportExcelService 
 		cell3.setCellStyle(style);
 
 		ICell cell4 = row.createCell(rowNumber.getAndIncrement());
-		cell4.setCellValue(content.getAttentionDate());
+		cell4.setCellValue(reformatdate.ReformatDateFour(content.getAttentionDate()));
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
@@ -680,7 +687,7 @@ public class NursingReportExcelServiceImpl implements NursingReportExcelService 
 		cell10.setCellStyle(style);
 
 		ICell cell11 = row.createCell(rowNumber.getAndIncrement());
-		cell11.setCellValue(content.getBirthday());
+		cell11.setCellValue(reformatdate.ReformatDateThree(content.getBirthday()));
 		cell11.setCellStyle(style);
 
 		ICell cell12 = row.createCell(rowNumber.getAndIncrement());
@@ -789,7 +796,7 @@ public class NursingReportExcelServiceImpl implements NursingReportExcelService 
 		cell3.setCellStyle(style);
 
 		ICell cell4 = row.createCell(rowNumber.getAndIncrement());
-		cell4.setCellValue(content.getAttentionDate());
+		cell4.setCellValue(reformatdate.ReformatDateThree(content.getAttentionDate()));
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
@@ -805,7 +812,7 @@ public class NursingReportExcelServiceImpl implements NursingReportExcelService 
 		cell7.setCellStyle(style);
 
 		ICell cell8 = row.createCell(rowNumber.getAndIncrement());
-		cell8.setCellValue(content.getPatientBirthDate());
+		cell8.setCellValue(reformatdate.ReformatDateThree(content.getPatientBirthDate()));
 		cell8.setCellStyle(style);
 
 		ICell cell9 = row.createCell(rowNumber.getAndIncrement());

--- a/back-end/hospital-api/src/main/java/net/pladema/olderadultsreports/service/impl/OlderAdultsReportExcelServiceImpl.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/olderadultsreports/service/impl/OlderAdultsReportExcelServiceImpl.java
@@ -11,6 +11,7 @@ import net.pladema.olderadultsreports.repository.OlderAdultsHospitalizationConsu
 import net.pladema.olderadultsreports.repository.OlderAdultsOutpatientConsultationDetail;
 import net.pladema.olderadultsreports.repository.PolypharmacyConsultationDetail;
 import net.pladema.olderadultsreports.service.OlderAdultsReportExcelService;
+import net.pladema.reportformat.DateFormat;
 
 import org.springframework.stereotype.Service;
 
@@ -27,6 +28,11 @@ public class OlderAdultsReportExcelServiceImpl implements OlderAdultsReportExcel
 	private ICellStyle titleStyle;
 	private ICellStyle fieldStyle;
 	private ICellStyle subTitleStyle;
+	private final DateFormat reformatdate;
+
+	public OlderAdultsReportExcelServiceImpl(DateFormat reformatdate) {
+		this.reformatdate = reformatdate;
+	}
 
 
 	@Override
@@ -267,7 +273,7 @@ public class OlderAdultsReportExcelServiceImpl implements OlderAdultsReportExcel
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
-		cell5.setCellValue(content.getAttentionDate());
+		cell5.setCellValue(reformatdate.ReformatDateThree(content.getAttentionDate()));
 		cell5.setCellStyle(style);
 
 		ICell cell6 = row.createCell(rowNumber.getAndIncrement());
@@ -291,7 +297,7 @@ public class OlderAdultsReportExcelServiceImpl implements OlderAdultsReportExcel
 		cell10.setCellStyle(style);
 
 		ICell cell11 = row.createCell(rowNumber.getAndIncrement());
-		cell11.setCellValue(content.getBirthDate());
+		cell11.setCellValue(reformatdate.ReformatDateFive(content.getBirthDate()));
 		cell11.setCellStyle(style);
 
 		ICell cell12 = row.createCell(rowNumber.getAndIncrement());
@@ -348,7 +354,7 @@ public class OlderAdultsReportExcelServiceImpl implements OlderAdultsReportExcel
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
-		cell5.setCellValue(content.getBirthDate());
+		cell5.setCellValue(reformatdate.ReformatDateThree(content.getBirthDate()));
 		cell5.setCellStyle(style);
 
 		ICell cell6 = row.createCell(rowNumber.getAndIncrement());
@@ -364,7 +370,7 @@ public class OlderAdultsReportExcelServiceImpl implements OlderAdultsReportExcel
 		cell8.setCellStyle(style);
 
 		ICell cell9 = row.createCell(rowNumber.getAndIncrement());
-		cell9.setCellValue(content.getEntrance());
+		cell9.setCellValue(reformatdate.ReformatDateTwo(content.getEntrance()));
 		cell9.setCellStyle(style);
 
 		ICell cell10 = row.createCell(rowNumber.getAndIncrement());
@@ -453,7 +459,7 @@ public class OlderAdultsReportExcelServiceImpl implements OlderAdultsReportExcel
 		cell12.setCellStyle(style);
 
 		ICell cell13 = row.createCell(rowNumber.getAndIncrement());
-		cell13.setCellValue(content.getStartDate());
+		cell13.setCellValue(reformatdate.ReformatDateFour(content.getStartDate()));
 		cell13.setCellStyle(style);
 
 		ICell cell14 = row.createCell(rowNumber.getAndIncrement());

--- a/back-end/hospital-api/src/main/java/net/pladema/programreports/service/impl/ProgramReportExcelServiceImpl.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/programreports/service/impl/ProgramReportExcelServiceImpl.java
@@ -14,6 +14,7 @@ import net.pladema.programreports.repository.RecuperoOdontologicoConsultationDet
 import net.pladema.programreports.repository.SumarGeneralConsultationDetail;
 import net.pladema.programreports.repository.SumarOdontologicoConsultationDetail;
 import net.pladema.programreports.service.ProgramReportExcelService;
+import net.pladema.reportformat.DateFormat;
 
 import org.springframework.stereotype.Service;
 
@@ -31,6 +32,12 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 	private ICellStyle titleStyle;
 	private ICellStyle fieldStyle;
 	private ICellStyle subTitleStyle;
+
+	private final DateFormat reformatdate;
+
+	public ProgramReportExcelServiceImpl(DateFormat reformatdate) {
+		this.reformatdate = reformatdate;
+	}
 
 	@Override
 	public IWorkbook buildExcelEpidemiologyOne(String title, String[] headers, List<EpidemiologyOneConsultationDetail> result) {
@@ -317,7 +324,7 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 		cell2.setCellStyle(style);
 
 		ICell cell3 = row.createCell(rowNumber.getAndIncrement());
-		cell3.setCellValue(content.getBirthDate());
+		cell3.setCellValue(reformatdate.ReformatDate(content.getBirthDate()));
 		cell3.setCellStyle(style);
 
 		ICell cell4 = row.createCell(rowNumber.getAndIncrement());
@@ -325,7 +332,7 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
-		cell5.setCellValue(content.getStartDate());
+		cell5.setCellValue(reformatdate.ReformatDate(content.getStartDate()));
 		cell5.setCellStyle(style);
 
 		ICell cell6 = row.createCell(rowNumber.getAndIncrement());
@@ -387,7 +394,7 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 		cell3.setCellStyle(style);
 
 		ICell cell4 = row.createCell(rowNumber.getAndIncrement());
-		cell4.setCellValue(content.getAttentionDate());
+		cell4.setCellValue(reformatdate.ReformatDateThree(content.getAttentionDate()));
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
@@ -411,7 +418,7 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 		cell9.setCellStyle(style);
 
 		ICell cell10 = row.createCell(rowNumber.getAndIncrement());
-		cell10.setCellValue(content.getBirthDate());
+		cell10.setCellValue(reformatdate.ReformatDateFive(content.getBirthDate()));
 		cell10.setCellStyle(style);
 
 		ICell cell11 = row.createCell(rowNumber.getAndIncrement());
@@ -476,7 +483,7 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 		cell3.setCellStyle(style);
 
 		ICell cell4 = row.createCell(rowNumber.getAndIncrement());
-		cell4.setCellValue(content.getAttentionDate());
+		cell4.setCellValue(reformatdate.ReformatDateThree(content.getAttentionDate()));
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
@@ -496,7 +503,7 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 		cell8.setCellStyle(style);
 
 		ICell cell9 = row.createCell(rowNumber.getAndIncrement());
-		cell9.setCellValue(content.getBirthDate());
+		cell9.setCellValue(reformatdate.ReformatDateFive(content.getBirthDate()));
 		cell9.setCellStyle(style);
 
 		ICell cell10 = row.createCell(rowNumber.getAndIncrement());
@@ -718,7 +725,7 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 		cell3.setCellStyle(style);
 
 		ICell cell4 = row.createCell(rowNumber.getAndIncrement());
-		cell4.setCellValue(content.getAttentionDate());
+		cell4.setCellValue(reformatdate.ReformatDateThree(content.getAttentionDate()));
 		cell4.setCellStyle(style);
 
 		ICell cell5 = row.createCell(rowNumber.getAndIncrement());
@@ -746,7 +753,7 @@ public class ProgramReportExcelServiceImpl implements ProgramReportExcelService 
 		cell10.setCellStyle(style);
 
 		ICell cell11 = row.createCell(rowNumber.getAndIncrement());
-		cell11.setCellValue(content.getBirthDate());
+		cell11.setCellValue(reformatdate.ReformatDateFive(content.getBirthDate()));
 		cell11.setCellStyle(style);
 
 		ICell cell12 = row.createCell(rowNumber.getAndIncrement());

--- a/back-end/hospital-api/src/main/java/net/pladema/reportformat/DateFormat.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/reportformat/DateFormat.java
@@ -1,0 +1,82 @@
+package net.pladema.reportformat;
+import lombok.SneakyThrows;
+
+import org.springframework.stereotype.Service;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Service
+public class DateFormat {
+	@SneakyThrows
+	public String ReformatDate (String previousDate) {
+
+		SimpleDateFormat inputFormat = new SimpleDateFormat("dd/MM/yyyy");
+		Date date = inputFormat.parse(previousDate);
+		SimpleDateFormat outputFormat = new SimpleDateFormat("dd-MM-yyyy");
+		return outputFormat.format(date);
+	}
+
+	public String ReformatDateTwo(String previousDate) {
+		SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date date= null;
+		try {
+			date = inputFormat.parse(previousDate);
+		} catch (ParseException e) {
+			throw new RuntimeException(e);
+
+		}
+
+		SimpleDateFormat outputFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm");
+		return outputFormat.format(date);
+
+	}
+
+	@SneakyThrows
+
+	public String ReformatDateThree(String previousDate) {
+		SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd");
+		Date date= null;
+		try {
+			date = inputFormat.parse(previousDate);
+		} catch (ParseException e) {
+			throw new RuntimeException(e);
+
+		}
+		SimpleDateFormat outputFormat = new SimpleDateFormat("dd-MM-yyyy");
+		return outputFormat.format(date);
+	}
+
+	public String ReformatDateFour (String previousDate) {
+		SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.ss");
+		Date date= null;
+		try {
+			date = inputFormat.parse(previousDate);
+		} catch (ParseException e) {
+			throw new RuntimeException(e);
+
+		}
+
+		SimpleDateFormat outputFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm");
+		return outputFormat.format(date);
+
+	}
+
+
+	@SneakyThrows
+	public String ReformatDateFive (String previousDate) {
+
+		if (previousDate !=null) {
+			SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd");
+			Date date = inputFormat.parse(previousDate);
+
+			SimpleDateFormat outputFormat = new SimpleDateFormat("dd-MM-yyyy");
+			return outputFormat.format(date);
+		} else {
+			return "NO ESPECIFICADO";
+		}
+	}
+
+
+}


### PR DESCRIPTION
## Modificación del formato de las fechas en Reportes Provinciales

Se realizó una modificación del formato de las fechas en los reportes Excel generados en el módulo de Reportes Provinciales.

### Sumario
Se agregó un paquete llamado **reporformat** con una clase **DateFormat.java** en el cual se alojan los métodos necesarios para hacer la modificación del formato de fechas en los Excel generados en el módulo de Reportes Provinciales de HSI.

### Cambios requeridos
Se pidió modificar el formato por defecto que muestra la fecha recogida de la base de datos al formato **dd-mm-yyyy** . 
Se encontraron varios formatos, algunos de los cuales incluían la fecha y hora hasta en milisegundos, lo cual dificultaba la legibilidad y comprensión de los datos debido a su extensión.

**Reportes modificados**
- Reportes generales
- Reportes de enfermería
- Reportes del adulto mayor
- Reportes de programas 

### Issue relacionado:
Closes #19 