### PR TITLE
Fixed/studies adult

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/components/emergente/pop-up/estudios-popup.component.scss
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/components/emergente/pop-up/estudios-popup.component.scss
@@ -1,18 +1,13 @@
-::ng-deep .mat-dialog-container {
-  padding: 0%;
- }
-
- ::ng-deep .mat-select-panel {
+::ng-deep .mat-select-panel {
   position: relative; 
   top: 15%;
 }
 .popup-container {
-    max-height: 710px;
-    overflow-y: auto;
+    max-height: 600px;
+    // overflow-y: auto;
     border: 1px solid #ccc;
     border-radius: 4px;
-    padding: 30px; //se cambio de 20px a 30px 
- 
+  
   }
 
   .mat-form-field {
@@ -24,11 +19,12 @@
   }
   
   .popup-container mat-label {
-    display: block;
+    display: block; 
     margin-bottom: 10px;
     box-shadow: 0 2px 4px rgba(63, 201, 255, 0.1);
   
   }
+
   
   .popup-container mat-select {
     width: 100%;
@@ -45,7 +41,8 @@
   .mat-button {
   
     float: right;
-    margin-top: -2.5%;  
-  }
+    position: relative;
+    bottom: 8px;
+   }
 
  

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/frail-scale.component.scss
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/frail-scale.component.scss
@@ -1,12 +1,9 @@
 .container {
-    padding-top: 15px;
-    padding: 20px;
-    max-width: 70%;
-    margin: auto;
+    padding: 28px;
+    max-width: 92%;
     border: 1px solid #e0eef7;
     box-shadow: 0px 3px 3px 0px rgba(179,177,179,1);
-    //margin-top: 3%;
-    text-align: left;
+    
      
   }
    


### PR DESCRIPTION
# FIX

Se llevó a cabo la corrección de un error asociado al componente mat-dialog, específicamente al abrir el cuadro emergente destinado a los adultos mayores. Se observó que otros componentes mat-dialog experimentaban un cambio en su padding debido al uso de ::ng-deep.

::ng-deep es un selector de pseudoclases empleado en CSS para anular estilos de un componente Angular. Su utilidad radica en la posibilidad de aplicar estilos a elementos internos de un componente, incluso si dichos elementos están definidos en otro componente.

> No obstante, el selector ::ng-deep presenta ciertas desventajas:

Dificultad de mantenimiento: La utilización de ::ng-deep puede complicar el mantenimiento del código, ya que determinar qué estilos se aplican a un elemento en particular puede resultar arduo. Esto se debe a que el selector ::ng-deep puede anular los estilos de cualquier componente, incluso de aquellos cuyo código fuente no está accesible.

Posible conflicto de estilos: El uso del selector ::ng-deep puede desencadenar conflictos de estilos si se aplica un estilo con el mismo nombre a un elemento dentro del componente. Esto se debe a que el selector ::ng-deep anulará todos los estilos, incluso aquellos definidos en el propio componente.

### Solución:

> Se descartó la utilización de ::ng-deep y se optó por otra vía de estilos mediante SCSS.

### Mejora adicional:

> Se optimizó el tamaño del cuadro emergente del formulario con el objetivo de mejorar la experiencia de navegación y la visibilidad para el usuario.

Issues relacionados:
Closes #29 

______________________________________________________________________________________________________

# FIX

A bug associated with the mat-dialog component was corrected, specifically when opening the pop-up box intended for older adults. Other mat-dialog components were observed to experience a change in their padding due to the use of ::ng-deep.

::ng-deep is a pseudoclass selector used in CSS to override styles from an Angular component. Its usefulness lies in the possibility of applying styles to internal elements of a component, even if said elements are defined in another component.

> However, the ::ng-deep selector has certain disadvantages:

Difficulty of maintenance: Using ::ng-deep can complicate code maintenance, as determining which styles apply to a particular element can be difficult. This is because the ::ng-deep selector can override the styles of any component, even those whose source code is not accessible.

Potential style conflict: Using the ::ng-deep selector can trigger style conflicts if a style with the same name is applied to an element within the component. This is because the ::ng-deep selector will override all styles, even those defined in the component itself.

### Solution:

> The use of ::ng-deep was discarded and another style route was chosen using SCSS.

### Additional improvement:

> The size of the form pop-up box was optimized with the aim of improving the navigation experience and visibility for the user.

Related issues:
Closes #29