### PR TITLE
Added functionality in question final

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/frail-scale.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/frail-scale.component.html
@@ -92,13 +92,7 @@
           <mat-radio-button color="primary" [style.color]="(selectedCalificacion === 'A5' || selectedCalificacion === 'B5') ? '#2687c5' : ''" id="50" value="B5" [disabled]="selectedCalificacion === 'A5'">Se considera PERSONA FRÁGIL</mat-radio-button>
         </mat-radio-group>
         
-  
-        
         <button mat-raised-button color="primary" [disabled]="isSubmitDisabled()" type="submit">Enviar Formulario</button>
       </div>
     </form>
   </div>
-
-  
-  
-  

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/frail-scale.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/frail-scale.component.html
@@ -87,14 +87,18 @@
       <div class="text">
         <h3 class="tipos" id="69">Interpretación de puntaje</h3>
         <p id="70">La sumatoria da como resultado:</p>
-        <mat-radio-group id="puntaje" name="points" [(ngModel)]="selectedCalificacion" [disabled]="true">
-          <mat-radio-button color="primary" id="49" value="A5">Se considera PERSONA PRE FRÁGIL</mat-radio-button>
-          <mat-radio-button color="primary" id="50" value="B5">Se considera PERSONA FRÁGIL</mat-radio-button>
+        <mat-radio-group id="puntaje" name="points" [(ngModel)]="selectedCalificacion">
+          <mat-radio-button color="primary"[style.color]="(selectedCalificacion === 'A5' || selectedCalificacion === 'B5') ? '#2687c5' : ''" id="49" value="A5" [disabled]="selectedCalificacion === 'B5'">Se considera PERSONA PRE FRÁGIL</mat-radio-button>
+          <mat-radio-button color="primary" [style.color]="(selectedCalificacion === 'A5' || selectedCalificacion === 'B5') ? '#2687c5' : ''" id="50" value="B5" [disabled]="selectedCalificacion === 'A5'">Se considera PERSONA FRÁGIL</mat-radio-button>
         </mat-radio-group>
+        
   
         
         <button mat-raised-button color="primary" [disabled]="isSubmitDisabled()" type="submit">Enviar Formulario</button>
       </div>
     </form>
   </div>
+
+  
+  
   


### PR DESCRIPTION
# Destacar resultado final de cuestionario Frail

### Descripcion de mejora: 
En la casilla "Interpretación de puntaje" se realizó una mejora que permite visualizar el resultado final del cuestionario como "PERSONA PRE FRAGIL" y "PERSONA FRAGIL" con el color solicitado #2687c5 (Hex)

Color:
![image](https://github.com/Historia-Clinica-La-Rioja/historia_clinica_LR/assets/113396981/179a3a4e-93d4-4753-8274-671a7e6d7334)

**Previamente a la mejora:**

![image](https://github.com/Historia-Clinica-La-Rioja/historia_clinica_LR/assets/113396981/b279f7e5-7d7b-4adf-b8a3-2622a1de8b2f)

**Resultado final:**

![image](https://github.com/Historia-Clinica-La-Rioja/historia_clinica_LR/assets/113396981/1613eee8-b9e9-47e4-92e5-7ef5cfbb09d7)

## Issues relacionados:
Close #38 