### PR TITLE
Improves aesthetics a frail form

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/frail-scale.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/frail-scale.component.html
@@ -96,3 +96,9 @@
       </div>
     </form>
   </div>
+
+      <!-- SALTO DE LINEA PARA EXTENDER FORMULARIO, ESTO NO ES LLM -->
+
+  <div>
+    <br>
+  </div>


### PR DESCRIPTION
# Mejora visual a formulario de Escala de Frail

Se agregó un salto de linea "br" dentro un "div" para extender el container que rodea al formulario, de tal manera mejora la visualización del mismo y aporta una vista agradable al usuario

### Antes:
![antes](https://github.com/Historia-Clinica-La-Rioja/historia_clinica_LR/assets/113396981/e0a779ce-e21c-4a2c-a19e-b57e0225a97c)

### Estado actual:
![WhatsApp Image 2024-01-11 at 12 55 23](https://github.com/Historia-Clinica-La-Rioja/historia_clinica_LR/assets/113396981/bc1d3b92-a69a-4ff8-9a55-5242f35938bc)
