### PR TITLE
feat: 'physical performance' questionnaire & universal 'create questionnaire' endpoint

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/domain/Answer.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/domain/Answer.java
@@ -5,8 +5,6 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import lombok.AllArgsConstructor;

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/domain/QuestionnaireResponseII.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/domain/QuestionnaireResponseII.java
@@ -1,36 +1,44 @@
 package net.pladema.questionnaires.common.domain;
 
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import ar.lamansys.sgx.auth.user.infrastructure.output.user.User;
+import ar.lamansys.sgx.shared.auditable.entity.SGXAuditableEntity;
+import ar.lamansys.sgx.shared.auditable.listener.SGXAuditListener;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import net.pladema.questionnaires.general.create.repository.entity.AnswerII;
 import net.pladema.staff.repository.entity.HealthcareProfessional;
 
 @Entity
 @Table(name = "minsal_lr_questionnaire_response", schema = "public")
+@EntityListeners(SGXAuditListener.class)
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-public class QuestionnaireResponseII {
+@JsonIgnoreProperties({"creationable", "updateable", "deleteable", "createdBy", "updatedBy"})
+public class QuestionnaireResponseII extends SGXAuditableEntity<Integer> {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,44 +55,17 @@ public class QuestionnaireResponseII {
 	@Column(name = "patient_id", nullable = false)
 	private Integer patientId;
 
-	@JsonIgnore
-	@Column(name = "created_by")
-	private Integer createdBy;
-
-	@JsonFormat(pattern = "dd-MM-yyyy HH:mm:ss")
-	@Column(name = "created_on", nullable = false)
-	private LocalDateTime createdOn;
-
 	@Transient
 	private String createdByFullName;
 
 	@Transient
 	private String createdByLicenseNumber;
 
-	@JsonIgnore
-	@Column(name = "updated_by")
-	private Integer updatedBy;
-
-	@JsonFormat(pattern = "dd-MM-yyyy HH:mm:ss")
-	@Column(name = "updated_on", nullable = false)
-	private LocalDateTime updatedOn;
-
 	@Transient
 	private String updatedByFullName;
 
 	@Transient
 	private String updatedByLicenseNumber;
-
-	@JsonIgnore
-	@Column(name = "deleted", nullable = false)
-	private Boolean deleted;
-
-	@JsonFormat(pattern = "dd-MM-yyyy HH:mm:ss")
-	@Column(name = "deleted_on")
-	private LocalDateTime deletedOn;
-
-	@Column(name = "deleted_by")
-	private Integer deletedBy;
 
 	@Setter
 	@Transient
@@ -104,6 +85,10 @@ public class QuestionnaireResponseII {
 	@ManyToOne
 	@JoinColumn(name = "updated_by", insertable = false, updatable = false)
 	private HealthcareProfessional updatedByHealthcareProfessional;
+
+	@JsonIgnore
+	@OneToMany(mappedBy = "questionnaireResponse", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<AnswerII> answers = new ArrayList<>();
 
 	public String getQuestionnaireType() {
 		if (questionnaireData != null) {

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/repository/QuestionnaireResponseRepository.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/repository/QuestionnaireResponseRepository.java
@@ -2,6 +2,7 @@ package net.pladema.questionnaires.common.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +16,6 @@ public interface QuestionnaireResponseRepository extends JpaRepository<Questionn
 	@Query("SELECT qr FROM QuestionnaireResponseII qr " +
 			"LEFT JOIN FETCH qr.createdByHealthcareProfessional chp " +
 			"WHERE qr.patientId = :patientId")
-	List<QuestionnaireResponseII> findResponsesWithCreatedByDetails(@Param("patientId") Integer patientId);
+	List<QuestionnaireResponseII> findResponsesWithCreatedByDetails(@Param("patientId") Integer patientId, Sort sort);
 
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/controller/CreateQuestionnaireController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/controller/CreateQuestionnaireController.java
@@ -1,0 +1,34 @@
+package net.pladema.questionnaires.general.create.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import net.pladema.questionnaires.common.domain.QuestionnaireResponseII;
+import net.pladema.questionnaires.general.create.domain.dto.QuestionnaireResponseDTO;
+import net.pladema.questionnaires.general.create.domain.service.CreateQuestionnaireService;
+
+@RestController
+@RequestMapping
+@Tag(name = "Patient consultation - General", description = "Patient consultation - General")
+public class CreateQuestionnaireController {
+
+	@Autowired
+	private CreateQuestionnaireService questionnaireService;
+
+	@PreAuthorize("hasPermission(#institutionId, 'ESPECIALISTA_MEDICO, PROFESIONAL_DE_SALUD, ENFERMERO_ADULTO_MAYOR, ENFERMERO, ESPECIALISTA_EN_ODONTOLOGIA')")
+	@PostMapping("institution/{institutionId}/patient/{patientId}/questionnaire/create")
+	public ResponseEntity<QuestionnaireResponseII> createQuestionnaireResponse(
+			@RequestBody QuestionnaireResponseDTO responseDTO, @PathVariable Integer institutionId, @PathVariable Integer patientId
+			) {
+		QuestionnaireResponseII createdResponse = questionnaireService.createQuestionnaireResponse(responseDTO, patientId);
+		return new ResponseEntity<>(createdResponse, HttpStatus.CREATED);
+	}
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/domain/dto/AnswerDTO.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/domain/dto/AnswerDTO.java
@@ -1,0 +1,20 @@
+package net.pladema.questionnaires.general.create.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class AnswerDTO {
+
+	private Integer itemId;
+
+	private Integer optionId;
+
+	private String value;
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/domain/dto/QuestionnaireResponseDTO.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/domain/dto/QuestionnaireResponseDTO.java
@@ -1,0 +1,20 @@
+package net.pladema.questionnaires.general.create.domain.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class QuestionnaireResponseDTO {
+
+	private Integer questionnaireId;
+
+	private List<AnswerDTO> answers;
+
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/domain/service/CreateQuestionnaireService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/domain/service/CreateQuestionnaireService.java
@@ -1,0 +1,52 @@
+package net.pladema.questionnaires.general.create.domain.service;
+
+import javax.transaction.Transactional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import net.pladema.questionnaires.common.domain.QuestionnaireResponseII;
+import net.pladema.questionnaires.common.repository.QuestionnaireResponseRepository;
+import net.pladema.questionnaires.general.create.domain.dto.AnswerDTO;
+import net.pladema.questionnaires.general.create.domain.dto.QuestionnaireResponseDTO;
+import net.pladema.questionnaires.general.create.repository.entity.AnswerII;
+import net.pladema.questionnaires.general.create.repository.entity.AnswerRepositoryII;
+
+@Service
+public class CreateQuestionnaireService {
+
+	@Autowired
+	private QuestionnaireResponseRepository responseRepository;
+
+	@Autowired
+	private AnswerRepositoryII answerRepository;
+
+	@Transactional
+	public QuestionnaireResponseII createQuestionnaireResponse (QuestionnaireResponseDTO responseDTO, Integer patientId) {
+
+		QuestionnaireResponseII questionnaireResponse = new QuestionnaireResponseII();
+		questionnaireResponse.setQuestionnaireId(responseDTO.getQuestionnaireId());
+		questionnaireResponse.setPatientId(patientId);
+
+		questionnaireResponse.setStatusId(2);
+
+		responseRepository.save(questionnaireResponse);
+
+		for (AnswerDTO answerDTO : responseDTO.getAnswers()) {
+			AnswerII answer = new AnswerII();
+			answer.setItemId(answerDTO.getItemId());
+			answer.setValue(answerDTO.getValue());
+			if (answerDTO.getOptionId() != null && answerDTO.getOptionId() == 0) {
+				answer.setAnswerId(null);
+			} else {
+				answer.setAnswerId(answerDTO.getOptionId());
+			}
+
+			answer.setQuestionnaireResponse(questionnaireResponse);
+
+			answerRepository.save(answer);
+		}
+
+		return questionnaireResponse;
+    }
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/repository/entity/AnswerII.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/repository/entity/AnswerII.java
@@ -1,0 +1,47 @@
+package net.pladema.questionnaires.general.create.repository.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import net.pladema.questionnaires.common.domain.QuestionnaireResponseII;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "minsal_lr_answer", schema = "public")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerII {
+
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "questionnaire_response_id")
+	private QuestionnaireResponseII questionnaireResponse;
+
+	@Column(name = "item_id", nullable = false)
+	private Integer itemId;
+
+	@Column(name = "value", length = 100)
+	private String value;
+
+	@Column(name = "option_id")
+	private Integer answerId;
+
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/repository/entity/AnswerRepositoryII.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/repository/entity/AnswerRepositoryII.java
@@ -1,0 +1,8 @@
+package net.pladema.questionnaires.general.create.repository.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnswerRepositoryII extends JpaRepository<AnswerII, Integer> {
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/domain/service/GetAllService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/domain/service/GetAllService.java
@@ -3,6 +3,7 @@ package net.pladema.questionnaires.general.getall.domain.service;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
 
@@ -32,7 +33,9 @@ public class GetAllService {
     }
 
 	public List<QuestionnaireResponseII> getResponsesByPatientIdWithDetails(Integer patientId) {
-		return questionnaireResponseRepository.findResponsesWithCreatedByDetails(patientId);
+		Sort sort = Sort.by(Sort.Order.desc("id"));
+
+		return questionnaireResponseRepository.findResponsesWithCreatedByDetails(patientId, sort);
 	}
 
 	public String getFullNameByHealthcareProfessionalId(Integer healthcareProfessionalId) {

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getpdf/controller/GetQuestionnairePdfController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getpdf/controller/GetQuestionnairePdfController.java
@@ -77,7 +77,7 @@ public class GetQuestionnairePdfController {
 	}
 
 	private ResponseEntity<InputStreamResource> generatePdfResponse(Map<String, Object> context, String outputFileName, Integer questionnaireId) throws IOException {
-		logger.debug("input parameters -> context: {}, outputFileName {}", context, outputFileName);
+		logger.debug("input parameters -> context: {}, outputFileName {}, questionnaireId: {}", context, outputFileName, questionnaireId);
 		String templateName = "";
 		if (questionnaireId == 1) {
 			templateName = "edmonton_reports";
@@ -87,6 +87,9 @@ public class GetQuestionnairePdfController {
 		}
 		if (questionnaireId == 3) {
 			templateName = "frail_reports";
+		}
+		if (questionnaireId == 4) {
+			templateName = "physicalperformance_reports";
 		}
 
 		FileContentBo fileContentBo = pdfService.generate(templateName, context);

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"></meta>
+    <meta name="viewport" content="width=device-width, initial-scale=1"></meta>
+    <title>Prueba de desempeño físico de adulto mayor</title>
+    <!-- Bootstrap's .css -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous"></link>
+    <style>
+        body {
+           border: 1px solid black;
+           padding: 10px;
+           font-family: Tahoma, Verdana, sans-serif;
+        }
+
+        h5 {
+           font-weight: bold;
+           font-size: 15px;
+           margin: 15px 0px;
+           border-top: 1px solid black;
+        }
+
+        h4 {
+           margin: 15px 0px;
+           color: #2687c5;
+           background-color: #f0f8ff;
+           border-top: 1px solid black;
+           font-weight: normal;
+        }
+
+        p {
+           font-weight: bold;
+           font-size: 15px;
+        }
+
+        label {
+           width: 70%;
+           page-break-inside: avoid;
+           margin: 2px 0px;
+        }
+
+        span {
+           font-weight: normal;
+        }
+
+    </style>
+</head>
+<body th:fragment="physicalperformance">
+    <div class="container">
+        <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
+        <p>Institución: <span th:text="${institution.name}"></span></p>
+        <hr></hr>
+        <h5>Detalles del paciente</h5>
+        <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>
+        <p><span th:utext="${'<b>' + patientIdType.description + ':</b> ' + patientPerson.identificationNumber}"></span></p>
+        <p>Edad a la fecha de atención: <span th:text="${patientAge}"></span></p>
+        <hr></hr>
+        <h5>Detalles del profesional</h5>
+        <p>Apellido y nombre: <span th:text="${professionalPersonFullName}"></span></p>
+        <p>Licencia: <span th:text="${professional.licenseNumber}"></span></p>
+
+        <h3>Prueba de desempeño físico de adulto mayor - Resultados de informe</h3>
+
+        <hr></hr>
+
+        <div class="itemcontainer" th:each="respuesta : ${answers[0]}">
+            <h4>Prueba de balance</h4>
+            <p>Párese con los pies uno al lado del otro: ¿mantuvo la posición al menos 10 segundos? si el participante no logró completarlo, finaliza la prueba de balance.</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
+                Sí
+            </label><br></br>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 19}"></input>
+                No
+            </label><br></br>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
+                Se niega
+            </label><br></br>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[1]}">
+            <p>Tiempo registrado (segundos)</p>
+            <label>
+                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+            </label>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[2]}">
+            <p>Párese en posición semi tándem: ¿mantuvo la posición al menos 10 segundos? si el participante no logró completarlo, finaliza la prueba de balance.</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
+                Sí
+            </label><br></br>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 19}"></input>
+                No
+            </label><br></br>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
+                Se niega
+            </label><br></br>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[3]}">
+            <p>Tiempo registrado (segundos)</p>
+            <label>
+                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+            </label>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[4]}">
+            <p>Párese en posición tándem: ¿mantuvo la posición al menos 10 segundos?</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
+                Se niega
+            </label><br></br>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[5]}">
+            <p>Tiempo registrado (segundos)</p>
+            <label>
+                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+            </label>
+        </div>
+
+        <p style="text-align: right; margin-top: 3em;">1/2</p>
+
+        <div class="itemcontainer" th:each="respuesta : ${answers[6]}">
+            <h4>Velocidad de marcha</h4>
+            <p>En esta oportunidad, la prueba requiere medir el tiempo en segundos para la realización de la prueba de velocidad de marcha en una distancia de 4 metros.</p>
+            <p>Primera medición: tiempo requerido para recorrer la distancia. Si el participante no logra completarla, finaliza la prueba.</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
+                Se niega
+            </label><br></br>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[7]}">
+            <p>Tiempo registrado (segundos)</p>
+            <label>
+                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}" ></p>
+            </label>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[8]}">
+            <p>Segunda medición: tiempo requerido para recorrer la distancia.</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
+                Se niega
+            </label><br></br>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[9]}">
+            <p>Tiempo registrado (segundos)</p>
+            <label>
+                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+            </label>
+        </div>
+        
+        <hr></hr>
+
+        <div class="itemcontainer" th:each="respuesta : ${answers[10]}">
+            <h4>Prueba de levantarse cinco veces de un asiento</h4>
+            <p>Prueba previa (no se califica): ¿el paciente se levanta sin apoyarse en sus brazos? si el participante no logra completarlo, finaliza la prueba.</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
+                Sí
+            </label><br></br>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 19}"></input>
+                No
+            </label><br></br>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
+                Se niega
+            </label><br></br>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[11]}">
+            <p>Prueba de levantarse cinco veces repetidamente de una silla: ¿el participante puede levantarse cinco veces de la silla sin usar sus brazos?</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
+                Sí
+            </label><br></br>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 19}"></input>
+                No
+            </label><br></br>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
+                Se niega
+            </label><br></br>
+        </div>
+        <hr></hr>
+        <div class="itemcontainer" th:each="respuesta : ${answers[12]}">
+            <p>Tiempo registrado (segundos)</p>
+            <label>
+                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+            </label>
+        </div>
+
+        <hr></hr>
+
+        <p style="text-align: right; margin-top: 3em;">2/2</p>
+
+    </div>
+    <!-- Bootstrap's script -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
### Descripción

Este pull request introduce cambios. Abajo van los detalles de cada cambio

1. ** Endpoint POST universal para crear respuestas de cuestionarios: **

- Siguiendo la filosofía del endpoint _GET_ para descargar .pdfs de cualquier cuestionario, se añade este endpoint _POST_ para crear cualquier tipo de cuestionario (a la fecha del día, esto es: Antecedentes familiares, Edmonton, Frail y Desempeño físico). El objetivo de este cambio es reducir enormemente la redundancia de código y mejorar la integración de cuestionarios que se añadan en un futuro. Este cambio haría obsoletos los endpoints _POST_ previamente creados ya que su objetivo es el mismo, sin embargo, no se los ha elimina, de forma que los desarrolladores front-end puedan hacer el cambio al ritmo que puedan.
- Detalles técnicos:
   - Endpoint: `/institution/{institutionId}/patient/{patientId}/questionnaire/create`
   - Parámetros:
     - `institutionId`: número _entero_ que identifica una institución. En este caso, solo se usa para dar seguridad a nivel de método.
     - `patientId`: número _entero_ que representa al paciente para el cual se registra la respuesta del cuestionario.
     - Request body:
```
{
  "questionnaireId": 1,
  "answers": [
    {
      "itemId": 72,
      "optionId": 19,
      "value": "string"
    },
    {
      "itemId": 73,
      "optionId": 0,
      "value": "3"
    },
   ... (un objeto por cada ítem a responder del cuestionario)
  ]
}
```
      -