### PR TITLE
Add 'questionnaireTypeId' parameter to JSON response

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/repository/entity/QuestionnaireResponse.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/repository/entity/QuestionnaireResponse.java
@@ -68,6 +68,10 @@ public class QuestionnaireResponse extends SGXAuditableEntity<Integer> {
 
 	@Setter
 	@Transient
+	private Integer questionnaireTypeId;
+
+	@Setter
+	@Transient
 	private String questionnaireType;
 
 	@JsonIgnore
@@ -88,6 +92,14 @@ public class QuestionnaireResponse extends SGXAuditableEntity<Integer> {
 	@JsonIgnore
 	@OneToMany(mappedBy = "questionnaireResponse", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Answer> answers = new ArrayList<>();
+
+	public Integer getQuestionnaireTypeId() {
+		if (questionnaireData != null) {
+			return questionnaireData.getId();
+		} else {
+			return null;
+		}
+	}
 
 	public String getQuestionnaireType() {
 		if (questionnaireData != null) {


### PR DESCRIPTION
## Descripción

### Cambios

- Se añade el parámetro `questionnaireTypeId` a cada objeto JSON del endpoint que devuelve **detalles acerca de los cuestionarios que respondió un paciente**, por lo que cada objeto ahora tiene la siguiente forma:

```
{
    "id": 94,
    "statusId": 2,
    "createdByFullName": "Fulano de tal",
    "createdByLicenseNumber": "123987",
    "updatedByFullName": "Fulano de tal",
    "updatedByLicenseNumber": "123987",
    "questionnaireTypeId": 3,
    "questionnaireType": "Escala de Frail",
    "deleted": false,
    "updatedOn": "2023-11-08T15:53:50.307Z",
    "createdOn": "2023-11-08T15:53:50.307Z"
}
```

este endpoint sigue manteniendo su ruta de acceso original, esta es:

`/institution/{institutionId}/patient/{patientId}/all-questionnaire-responses`

con los parámetros **institutionId** y **patientId**.