### PR TITLE
Feat: create 'update questionnaire' PUT endpoint

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/dto/UpdateResponseDTO.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/dto/UpdateResponseDTO.java
@@ -1,0 +1,18 @@
+package net.pladema.questionnaires.common.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class UpdateResponseDTO {
+
+	private List<AnswerDTO> answers;
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/update/controller/UpdateQuestionnaireController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/update/controller/UpdateQuestionnaireController.java
@@ -1,0 +1,42 @@
+package net.pladema.questionnaires.general.update.controller;
+
+import ar.lamansys.sgx.shared.exceptions.NotFoundException;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import net.pladema.questionnaires.common.dto.UpdateResponseDTO;
+import net.pladema.questionnaires.general.update.domain.service.UpdateQuestionnaireService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+@Tag(name = "Patient questionnaires and assessments", description = "Patient questionnaires and assessments")
+public class UpdateQuestionnaireController {
+
+	@Autowired
+	private UpdateQuestionnaireService service;
+
+	@PreAuthorize("hasPermission(#institutionId, 'ESPECIALISTA_MEDICO, PROFESIONAL_DE_SALUD, ENFERMERO_ADULTO_MAYOR, ENFERMERO, ESPECIALISTA_EN_ODONTOLOGIA')")
+	@PutMapping("institution/{institutionId}/questionnaire/{questionnaireResponseId}/update")
+	public ResponseEntity<String> updateAnswers(
+			@RequestBody UpdateResponseDTO responseDTO, @PathVariable Integer institutionId, @PathVariable Integer questionnaireResponseId
+	) {
+		try {
+			service.updateAnswersAndQuestionnaireData(responseDTO, questionnaireResponseId);
+			return ResponseEntity.ok("Updated questionnaire successfully");
+		} catch (NotFoundException e) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to update questionnaire: " + e.getMessage());
+		}
+	}
+
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/update/domain/service/UpdateQuestionnaireService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/update/domain/service/UpdateQuestionnaireService.java
@@ -1,0 +1,65 @@
+package net.pladema.questionnaires.general.update.domain.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javassist.NotFoundException;
+import net.pladema.questionnaires.common.dto.AnswerDTO;
+import net.pladema.questionnaires.common.dto.UpdateResponseDTO;
+import net.pladema.questionnaires.common.repository.AnswerRepository;
+import net.pladema.questionnaires.common.repository.QuestionnaireResponseRepository;
+import net.pladema.questionnaires.common.repository.entity.Answer;
+import net.pladema.questionnaires.common.repository.entity.QuestionnaireResponse;
+
+@Service
+public class UpdateQuestionnaireService {
+
+	@Autowired
+	private AnswerRepository answerRepository;
+
+	@Autowired
+	private QuestionnaireResponseRepository questionnaireResponseRepository;
+
+	public void updateAnswersAndQuestionnaireData (UpdateResponseDTO responseDTO, Integer questionnaireResponseId) throws NotFoundException {
+
+		List<AnswerDTO> answerUpdates = responseDTO.getAnswers();
+
+		QuestionnaireResponse response = questionnaireResponseRepository.findById(questionnaireResponseId)
+				.orElseThrow(() -> new NotFoundException("Couldn't find questionnaire response with id " + questionnaireResponseId));
+
+		List<Answer> existingAnswers = answerRepository.findByQuestionnaireResponseId(questionnaireResponseId);
+
+		for (AnswerDTO answerDTO : answerUpdates) {
+			boolean answerFound = false;
+			for (Answer existingAnswer : existingAnswers) {
+				if (existingAnswer.getItemId().equals(answerDTO.getItemId())) {
+					if (answerDTO.getOptionId() != null && answerDTO.getOptionId() == 0) {
+						existingAnswer.setAnswerId(null);
+					} else {
+						existingAnswer.setAnswerId(answerDTO.getOptionId());
+					}
+					existingAnswer.setValue(answerDTO.getValue());
+					existingAnswer.setQuestionnaireResponse(response);
+					answerRepository.save(existingAnswer);
+					answerFound = true;
+					break;
+				}
+			}
+			if (!answerFound) {
+				Answer newAnswer = new Answer();
+				newAnswer.setItemId(answerDTO.getItemId());
+				newAnswer.setAnswerId(answerDTO.getOptionId());
+				newAnswer.setValue(answerDTO.getValue());
+				newAnswer.setQuestionnaireResponse(response);
+				answerRepository.save(newAnswer);
+			}
+		}
+
+		response.setUpdatedOn(LocalDateTime.now());
+		questionnaireResponseRepository.save(response);
+
+	}
+}


### PR DESCRIPTION
# Descripción

## Cambios introducidos

#### Endpoint PUT (actualizar/modificar cuestionario)

Este PR añade un nuevo endpoint para el tratamiento de cuestionarios y pruebas, el cuál permite modificar las respuestas asociadas a un cuestionario, ya sea por que estén ingresadas erróneamente, como por que faltaron agregar ciertas respuestas en la carga original: en este caso, el endpoint crea las respuestas faltantes adecuadamente.
Si no se halla una respuesta con la  enviada como parámetro, nos devuelve un código `500 - Internal server error` con la respuesta `Failed to update questionnaire: Couldn't find questionnaire response with id X`; en caso que actualice con éxito recibimos un `200 - OK` y el response body `Updated questionnaire successfully`

##### Ruta de acceso

- `/institution/{institutionId}/questionnaire/{questionnaireResponseId}/update`

##### Parámetros de ruta

- `institutionId`
- `questionnaireResponseId`

##### Cuerpo de petición

En este ejemplo, se actualizan algunas respuestas de un cuestionario de **desempeño físico**.

```
{
  "answers": [
    {
      "itemId": 72,
      "optionId": 19,
      "value": "string"
    },
    {
      "itemId": 73,
      "optionId": 0,
      "value": "3"
    },
    {
      "itemId": 74,
      "optionId": 19,
      "value": "string"
    },
    ... (un objeto JSON por cada respuesta a actualizar)
  ]
}
```

## Desarrolladores asociados

- @RodrigoCba96 
- @cquevedox 