### PR TITLE
Feat: add POST and GET endpoints for the errata feature

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/errata/common/dto/ErrataRequestDTO.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/common/dto/ErrataRequestDTO.java
@@ -1,0 +1,18 @@
+package net.pladema.errata.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class ErrataRequestDTO {
+
+	private String description;
+
+	private Integer documentId;
+
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/errata/common/repository/ErrataRepository.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/common/repository/ErrataRepository.java
@@ -1,0 +1,17 @@
+package net.pladema.errata.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import net.pladema.errata.common.repository.entity.Errata;
+
+import java.util.List;
+
+@Repository
+public interface ErrataRepository extends JpaRepository<Errata, Integer> {
+
+	boolean existsByDocumentId(Integer documentId);
+
+	Errata findByDocumentId(Integer documentId);
+
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/errata/common/repository/entity/Errata.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/common/repository/entity/Errata.java
@@ -1,0 +1,34 @@
+package net.pladema.errata.common.repository.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "minsal_lr_errata", schema = "public")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Errata {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@Column(nullable = false)
+	private String description;
+
+	@Column(name = "document_id", nullable = false)
+	private Integer documentId;
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/errata/general/endpoints/controller/ErrataController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/general/endpoints/controller/ErrataController.java
@@ -1,0 +1,62 @@
+package net.pladema.errata.general.endpoints.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import net.pladema.errata.common.dto.ErrataRequestDTO;
+import net.pladema.errata.common.repository.entity.Errata;
+import net.pladema.errata.general.endpoints.service.ErrataService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+@Tag(name = "Errata", description = "Errata")
+public class ErrataController {
+
+	@Autowired
+	private final ErrataService errataService;
+
+
+    public ErrataController(ErrataService errataService) {
+        this.errataService = errataService;
+    }
+
+	@PreAuthorize("hasPermission(#institutionId, 'ESPECIALISTA_MEDICO, PROFESIONAL_DE_SALUD, ENFERMERO_ADULTO_MAYOR, ENFERMERO, ESPECIALISTA_EN_ODONTOLOGIA')")
+	@PostMapping("institution/{institutionId}/errata/create")
+	public ResponseEntity<?> createErrata(
+			@RequestBody ErrataRequestDTO requestDTO, @PathVariable Integer institutionId
+			) {
+		try {
+			Errata errata = errataService.createErrata(requestDTO);
+			return ResponseEntity.ok(errata);
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error creating errata with document ID " + requestDTO.getDocumentId());
+		}
+	}
+
+	@PreAuthorize("hasPermission(#institutionId, 'ESPECIALISTA_MEDICO, PROFESIONAL_DE_SALUD, ENFERMERO_ADULTO_MAYOR, ENFERMERO, ESPECIALISTA_EN_ODONTOLOGIA')")
+	@GetMapping("institution/{institutionId}/document/{documentId}/errata")
+	public ResponseEntity<?> getErrataByDocumentId(
+			@PathVariable Integer institutionId, @PathVariable Integer documentId
+	) {
+		try {
+			Errata errata = errataService.getErrataByDocumentId(documentId);
+			if (errata != null) {
+				return ResponseEntity.ok(errata);
+			} else {
+				return ResponseEntity.notFound().build();
+			}
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error retrieving errata for document ID " + documentId);
+		}
+	}
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/errata/general/endpoints/service/ErrataService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/general/endpoints/service/ErrataService.java
@@ -1,0 +1,36 @@
+package net.pladema.errata.general.endpoints.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import ar.lamansys.sgh.clinichistory.infrastructure.output.repository.document.DocumentRepository;
+import net.pladema.errata.common.dto.ErrataRequestDTO;
+import net.pladema.errata.common.repository.ErrataRepository;
+import net.pladema.errata.common.repository.entity.Errata;
+
+@Service
+public class ErrataService {
+
+	@Autowired
+	private final ErrataRepository errataRepository;
+
+    public ErrataService(ErrataRepository errataRepository) {
+        this.errataRepository = errataRepository;
+    }
+
+	public Errata createErrata(ErrataRequestDTO requestDTO) {
+		boolean errataExists = errataRepository.existsByDocumentId(requestDTO.getDocumentId());
+		if (errataExists) {
+			throw new RuntimeException("An errata already exists for the document with the ID " + requestDTO.getDocumentId());
+		}
+
+		Errata errata = new Errata();
+		errata.setDescription(requestDTO.getDescription());
+		errata.setDocumentId(requestDTO.getDocumentId());
+		return errataRepository.save(errata);
+	}
+
+	public Errata getErrataByDocumentId(Integer documentId) {
+		return errataRepository.findByDocumentId(documentId);
+	}
+}


### PR DESCRIPTION
### Description

This PR introduces two new endpoints to the API:

1. POST `/institution/{institutionId}/errata/create/`
2. GET `/institution/{institutionId}/document/{documentId}/errata`

**There's only one task left, which would be only allowing the creation of an errata only to the creator of the original -associated- document, but other than that, the endpoint works OK.**

### Changes

- Add a new controller for the `POST /institution/{institutionId}/errata/create/` endpoint
    - `institutionId` is the only route parameter, used for method authorization.
    - This endpoint creates a new errata associated to a document.
    - Request body contains the errata's `description` and the related document's `id`.

``` json
{
  "description": "Hola mundo",
  "documentId": 1
}
```

- Add a new controller for the `GET /institution/{institutionId}/document/{documentId}/errata` endpoint
   - `institutionId` and `documentId` are the route parameters, used for method authorization and resource identification, respectively.
   - This endpoint's response body is as follows:

``` json
{
  "id": 1,
  "description": "Hola mundo",
  "documentId": 1
}
```

### Additional notes

- The DB tables should be added for this feature to work (ask @DocOc98 for the code or use the following (I got it from PGAdmin from the table obtained in the backup))

``` sql
-- Table: public.minsal_lr_errata

-- DROP TABLE IF EXISTS public.minsal_lr_errata;

CREATE TABLE IF NOT EXISTS public.minsal_lr_errata
(
    id integer NOT NULL DEFAULT nextval('minsal_lr_errata_id_seq'::regclass),
    description text COLLATE pg_catalog."default" NOT NULL,
    document_id integer NOT NULL,
    CONSTRAINT minsal_lr_errata_pkey PRIMARY KEY (id),
    CONSTRAINT minsal_lr_errata_document_id_fkey FOREIGN KEY (document_id)
        REFERENCES public.document (id) MATCH SIMPLE
        ON UPDATE NO ACTION
        ON DELETE NO ACTION
)

TABLESPACE pg_default;

ALTER TABLE IF EXISTS public.minsal_lr_errata
    OWNER to postgres;
```

- Basic error handling implemented (returns HTTP status codes and messages)
- Auth checks added to the endpoints

### Relevant developers

- @cquevedox 
- @RodrigoCba96 