### PR TITLE
[Frontend] Reportes de Dengue

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/api-rest/services/dengue-reports.service.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/api-rest/services/dengue-reports.service.ts
@@ -21,12 +21,12 @@ export class DengueReportsService {
   }
 
   getDengueAttentionsReport(params: any, fileName: string): Observable<any> {
-    const url = `${environment.apiBase}/epidemiologyreports/${this.contextService.institutionId}/complete-dengue`;
+    const url = `${environment.apiBase}/epidemiologyreports/${this.contextService.institutionId}/dengue-patient-control`;
     return this.getDengueReport(params, fileName, url);
   }
 
   getDengueControlsReport(params: any, fileName: string): Observable<any> {
-    const url = `${environment.apiBase}/epidemiologyreports/${this.contextService.institutionId}/dengue-patient-control`;
+    const url = `${environment.apiBase}/epidemiologyreports/${this.contextService.institutionId}/complete-dengue`;
     return this.getDengueReport(params, fileName, url);
   }
 

--- a/front-end/apps/projects/hospital/src/app/modules/api-rest/services/dengue-reports.service.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/api-rest/services/dengue-reports.service.ts
@@ -1,0 +1,33 @@
+import { HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ContextService } from '@core/services/context.service';
+import { DownloadService } from '@core/services/download.service';
+import { environment } from '@environments/environment';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DengueReportsService {
+
+  constructor(
+    private contextService: ContextService,
+    private downloadService: DownloadService,
+  ) { }
+
+  private getDengueReport(params: any, fileName: string, url: any): Observable<any> {
+    let requestParams: HttpParams = new HttpParams();
+    return this.downloadService.downloadXlsWithRequestParams(url, fileName, requestParams);
+  }
+
+  getDengueAttentionsReport(params: any, fileName: string): Observable<any> {
+    const url = `${environment.apiBase}/epidemiologyreports/${this.contextService.institutionId}/complete-dengue`;
+    return this.getDengueReport(params, fileName, url);
+  }
+
+  getDengueControlsReport(params: any, fileName: string): Observable<any> {
+    const url = `${environment.apiBase}/epidemiologyreports/${this.contextService.institutionId}/dengue-patient-control`;
+    return this.getDengueReport(params, fileName, url);
+  }
+
+}

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/constants/dengue-report-types.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/constants/dengue-report-types.ts
@@ -1,10 +1,10 @@
 export const DENGUE_REPORT_TYPES = [
     {
         description: 'Atenciones relacionadas al Dengue - Control de pacientes',
-        id: 2,
+        id: 1,
     },
     {
         description: 'Atenciones relacionadas al Dengue - Consultas completas',
-        id: 1,
+        id: 2,
     }
 ]

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/constants/dengue-report-types.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/constants/dengue-report-types.ts
@@ -1,0 +1,10 @@
+export const DENGUE_REPORT_TYPES = [
+    {
+        description: 'Atenciones relacionadas al Dengue - Control de pacientes',
+        id: 2,
+    },
+    {
+        description: 'Atenciones relacionadas al Dengue - Consultas completas',
+        id: 1,
+    }
+]

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.html
@@ -31,3 +31,5 @@
             </button>
         </div>
     </form>
+
+</app-content>

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.html
@@ -1,0 +1,33 @@
+<app-content>
+
+    <h2 [translate]="'reportes.form.TITLE'"></h2>
+    <form [formGroup]="form">
+        <div id="report-type" fxLayout="column">
+            <div>
+                <mat-label [translate]="'reportes.form.REPORT_TYPE'"></mat-label>
+            </div>
+            <div fxLayout="row">
+                <mat-form-field fxFlex.gt-xs="50%" appearance="outline">
+                    <mat-select id="report-type-select-group"
+                                name="reportTypeSelectGroup"
+                                formControlName="reportType"
+                                placeholder="{{'pacientes.form.SELECT' | translate}}">
+                        <mat-option *ngFor="let reportType of REPORT_TYPES"
+                                    [value]="reportType.id">
+                            {{reportType.description}} 
+                        </mat-option>
+                    </mat-select>
+                    <mat-error *ngIf="submitted && hasError(form, 'required', 'reportType')">
+                        <span translate="forms.REQUIRED"></span>
+                    </mat-error>
+                </mat-form-field>
+            </div>
+            <span class="text"> LOS REPORTES SE GENERAN EN EL LAPSO TRANSCURRIDO DESDE LAS 00:00H A LAS 23:59H DEL DÍA EN CURSO </span>
+            <span class="observation">Se recomienda una lectura exhaustiva de las observaciones presentes en cada uno de los reportes generados. Asimismo, se sugiere elaborar ambos reportes para realizar una adecuada comparación de la información.</span>
+        </div>
+        <div fxLayout="row" fxLayoutAlign="end" style="margin-top: 20px">
+            <button class="uppercase" mat-raised-button color="primary" (click)="generateDengueReport()">
+                <span [translate]="'reportes.form.SUBMIT'"></span>
+            </button>
+        </div>
+    </form>

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.scss
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.scss
@@ -1,0 +1,27 @@
+#report-type > * {
+    padding-top: 5px;
+}
+
+#report-type-radio-group > * {
+    padding-top: 5px;
+    padding-bottom: 10px;
+}
+
+.required-field {
+    color: #9c9fa3;
+    font-size: 11px;
+    padding-left: 10px;
+}
+
+.text {
+    font: 500 15px / 30px Roboto, "Helvetica Neue", sans-serif;
+    margin-top: 15px;
+    margin-bottom: 8px;
+    text-align: center;
+    background: #2687c530;
+    border-radius: 3px;
+}
+
+.observation {
+    font: 500 15px/20px Roboto, "Helvetica Neue", sans-serif;
+}

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.ts
@@ -9,6 +9,7 @@ import { DengueReportsService } from '@api-rest/services/dengue-reports.service'
   templateUrl: './reporte-dengue.component.html',
   styleUrls: ['./reporte-dengue.component.scss']
 })
+
 export class ReporteDengueComponent implements OnInit {
 
     form: UntypedFormGroup;

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit } from '@angular/core';
+import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { hasError } from '@core/utils/form.utils';
+import { DENGUE_REPORT_TYPES } from './constants/dengue-report-types';
+import { DengueReportsService } from '@api-rest/services/dengue-reports.service';
+
+@Component({
+  selector: 'app-reporte-dengue',
+  templateUrl: './reporte-dengue.component.html',
+  styleUrls: ['./reporte-dengue.component.scss']
+})
+export class ReporteDengueComponent implements OnInit {
+
+    form: UntypedFormGroup;
+    public submitted = false;
+  
+    public hasError = hasError;
+  
+    REPORT_TYPES = DENGUE_REPORT_TYPES;
+    
+    constructor(
+      private readonly formBuilder: UntypedFormBuilder,
+      private readonly dengueReportsService: DengueReportsService,
+    ) { }
+  
+    ngOnInit(): void {
+      this.form = this.formBuilder.group({
+        reportType: [null, Validators.required],
+      });
+    }
+      generateDengueReport() {
+      this.submitted = true;
+      if(this.form.valid) {
+        const params = {
+        }
+        const dengueReportId = this.form.controls.reportType.value;
+        switch (dengueReportId) {
+          case 1:
+            this.dengueReportsService.getDengueAttentionsReport(params, `${this.REPORT_TYPES[0].description}.xls`).subscribe();
+            console.log('reporte consultas 1')
+            break;
+          case 2:
+            this.dengueReportsService.getDengueControlsReport(params, `${this.REPORT_TYPES[1].description}.xls`).subscribe();
+            console.log('reporte control 2')
+            break; 
+          default:
+        }
+      }
+    }
+  
+  }
+  

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reporte-dengue/reporte-dengue.component.ts
@@ -9,45 +9,43 @@ import { DengueReportsService } from '@api-rest/services/dengue-reports.service'
   templateUrl: './reporte-dengue.component.html',
   styleUrls: ['./reporte-dengue.component.scss']
 })
-
 export class ReporteDengueComponent implements OnInit {
 
-    form: UntypedFormGroup;
-    public submitted = false;
+  form: UntypedFormGroup;
+  public submitted = false;
   
-    public hasError = hasError;
+  public hasError = hasError;
   
-    REPORT_TYPES = DENGUE_REPORT_TYPES;
+  REPORT_TYPES = DENGUE_REPORT_TYPES;
     
-    constructor(
-      private readonly formBuilder: UntypedFormBuilder,
-      private readonly dengueReportsService: DengueReportsService,
-    ) { }
+  constructor(
+    private readonly formBuilder: UntypedFormBuilder,
+    private readonly dengueReportsService: DengueReportsService,
+  ) { }
   
-    ngOnInit(): void {
-      this.form = this.formBuilder.group({
-        reportType: [null, Validators.required],
-      });
-    }
-      generateDengueReport() {
-      this.submitted = true;
-      if(this.form.valid) {
-        const params = {
-        }
-        const dengueReportId = this.form.controls.reportType.value;
-        switch (dengueReportId) {
-          case 1:
-            this.dengueReportsService.getDengueAttentionsReport(params, `${this.REPORT_TYPES[0].description}.xls`).subscribe();
-            console.log('reporte consultas 1')
-            break;
-          case 2:
-            this.dengueReportsService.getDengueControlsReport(params, `${this.REPORT_TYPES[1].description}.xls`).subscribe();
-            console.log('reporte control 2')
-            break; 
-          default:
-        }
+  ngOnInit(): void {
+    this.form = this.formBuilder.group({
+      reportType: [null, Validators.required],
+    });
+  }
+
+  generateDengueReport() {
+    this.submitted = true;
+    if(this.form.valid) {
+      const params = {
+
+      }
+      const dengueReportId = this.form.controls.reportType.value;
+      switch (dengueReportId) {
+        case 1:
+          this.dengueReportsService.getDengueAttentionsReport(params, `${this.REPORT_TYPES[0].description}.xls`).subscribe();
+          break;
+        case 2:
+          this.dengueReportsService.getDengueControlsReport(params, `${this.REPORT_TYPES[1].description}.xls`).subscribe();
+          break;
+        default:
       }
     }
-  
   }
-  
+
+}

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja.component.html
@@ -55,6 +55,14 @@
                         <app-reportes-personagestante></app-reportes-personagestante>
                     </ng-template>
                 </mat-tab>
+                <mat-tab id="tab_personagestante">
+                    <ng-template mat-tab-label>
+                        <span>EPIDEMIOLOGÍA</span>
+                    </ng-template>
+                    <ng-template matTabContent>
+                     <app-reporte-dengue></app-reporte-dengue>
+                    </ng-template>
+                </mat-tab>
             </mat-tab-group>
         </mat-card-content>
     </mat-card>

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja.component.html
@@ -55,12 +55,12 @@
                         <app-reportes-personagestante></app-reportes-personagestante>
                     </ng-template>
                 </mat-tab>
-                <mat-tab id="tab_personagestante">
+                <mat-tab id="tab_epidemiologia">
                     <ng-template mat-tab-label>
                         <span>EPIDEMIOLOGÍA</span>
                     </ng-template>
                     <ng-template matTabContent>
-                     <app-reporte-dengue></app-reporte-dengue>
+                        <app-reporte-dengue></app-reporte-dengue>
                     </ng-template>
                 </mat-tab>
             </mat-tab-group>

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja.module.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja.module.ts
@@ -12,8 +12,9 @@ import { ReportesEnfermeriaComponent } from './reportes-enfermeria/reportes-enfe
 import { ReportesOdontologiaComponent } from './reportes-odontologia/reportes-odontologia.component';
 import { ReportesAdultomayorComponent } from './reportes-adultomayor/reportes-adultomayor.component';
 import { ReportesPersonagestanteComponent } from './reportes-personagestante/reportes-personagestante.component';
+import { ReporteDengueComponent } from './reporte-dengue/reporte-dengue.component';
 
-@NgModule({
+@@NgModule({
   declarations: [
     ReportesLariojaComponent,
     ReportesProgramasComponent,
@@ -21,7 +22,8 @@ import { ReportesPersonagestanteComponent } from './reportes-personagestante/rep
     ReportesEnfermeriaComponent,
     ReportesOdontologiaComponent,
     ReportesAdultomayorComponent,
-    ReportesPersonagestanteComponent
+    ReportesPersonagestanteComponent,
+    ReporteDengueComponent
   ],
   imports: [
     CommonModule,

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja.module.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-larioja.module.ts
@@ -14,7 +14,7 @@ import { ReportesAdultomayorComponent } from './reportes-adultomayor/reportes-ad
 import { ReportesPersonagestanteComponent } from './reportes-personagestante/reportes-personagestante.component';
 import { ReporteDengueComponent } from './reporte-dengue/reporte-dengue.component';
 
-@@NgModule({
+@NgModule({
   declarations: [
     ReportesLariojaComponent,
     ReportesProgramasComponent,


### PR DESCRIPTION
## Descripción
Esta pull request introduce una nueva pestaña para los reportes de Epidemiología en el frontend de la aplicación. La pestaña se integra dentro del módulo de Reportes Provinciales existente.

## Issues relacionadas
Closes: #111 

## Tareas realizadas:

1. Desarrollo de la pestaña de Epidemiología:

- Se creó una nueva pestaña dentro del módulo de Reportes Provinciales.
- Se diseñó la interfaz de usuario para la pestaña.
- Se implementó la lógica para la interacción del usuario con la pestaña, descartando la selección de fechas.
- Se incorporaron textos destacados a la interfaz dirigidos al usuario con el fin de exclarecer dudas con respecto a la restricción de las fechas y horario de generacón de los reportes.

2. Creación del servicio para recuperar reportes:
- Se desarrolló un servicio que se comunica con los 2 endpoints correspondientes para obtener los datos de los reportes de Atenciones Relacionadas con Dengue.

## Pruebas:

#### Se realizaron pruebas exhaustivas para garantizar el correcto funcionamiento de la nueva pestaña, incluyendo:

- Verificación de la visualización correcta de los datos de los reportes.
- Validación de la interacción del usuario con la pestaña y la descarga de reportes.
- Comprobación de la integración del servicio de recuperación de reportes.

## Vizualización de resultados
![image](https://github.com/Historia-Clinica-La-Rioja/historia_clinica_LR/assets/141648316/66d02b28-9f61-4b8d-8f70-9dca47a20062)


### Solicitamos su revisión y aprobación para integrar estos cambios en la base de código principal.
