### PR TITLE
feat: add author-restricted filter to errata creation endpoint

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/errata/common/dto/ErrataRequestDTO.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/common/dto/ErrataRequestDTO.java
@@ -15,4 +15,6 @@ public class ErrataRequestDTO {
 
 	private Integer documentId;
 
+	private Integer healthcareProfessionalId;
+
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/errata/common/repository/CustomDocumentRepository.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/common/repository/CustomDocumentRepository.java
@@ -1,0 +1,21 @@
+package net.pladema.errata.common.repository;
+
+
+import ar.lamansys.sgh.clinichistory.infrastructure.output.repository.document.entity.Document;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomDocumentRepository extends JpaRepository<Document, Long> {
+
+	@Query("SELECT CASE WHEN COUNT(d) > 0 THEN true ELSE false END " +
+			"FROM Document d " +
+			"WHERE d.id = :id AND " +
+			"(d.creationable.createdBy = :createdBy OR d.updateable.updatedBy = :updatedBy)")
+	boolean existsByIdAndCreatedByOrUpdatedBy(@Param("id") Long id,
+											  @Param("createdBy") Integer createdBy,
+											  @Param("updatedBy") Integer updatedBy);
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/errata/general/endpoints/service/ErrataService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/general/endpoints/service/ErrataService.java
@@ -1,9 +1,10 @@
 package net.pladema.errata.general.endpoints.service;
 
+import net.pladema.errata.common.repository.CustomDocumentRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import ar.lamansys.sgh.clinichistory.infrastructure.output.repository.document.DocumentRepository;
 import net.pladema.errata.common.dto.ErrataRequestDTO;
 import net.pladema.errata.common.repository.ErrataRepository;
 import net.pladema.errata.common.repository.entity.Errata;
@@ -13,15 +14,24 @@ public class ErrataService {
 
 	@Autowired
 	private final ErrataRepository errataRepository;
+	@Autowired
+	private final CustomDocumentRepository customDocumentRepository;
 
-    public ErrataService(ErrataRepository errataRepository) {
+	public ErrataService(ErrataRepository errataRepository, CustomDocumentRepository customDocumentRepository) {
         this.errataRepository = errataRepository;
-    }
+		this.customDocumentRepository = customDocumentRepository;
+	}
 
 	public Errata createErrata(ErrataRequestDTO requestDTO) {
+
 		boolean errataExists = errataRepository.existsByDocumentId(requestDTO.getDocumentId());
 		if (errataExists) {
 			throw new RuntimeException("An errata already exists for the document with the ID " + requestDTO.getDocumentId());
+		}
+
+		boolean isAuthorized = customDocumentRepository.existsByIdAndCreatedByOrUpdatedBy(Long.valueOf(requestDTO.getDocumentId()), requestDTO.getHealthcareProfessionalId(), requestDTO.getHealthcareProfessionalId());
+		if (!isAuthorized) {
+			throw new RuntimeException("You are not authorized to create an errata for document with ID " + requestDTO.getDocumentId());
 		}
 
 		Errata errata = new Errata();


### PR DESCRIPTION
# Description

This PR adds a filter to the errata registering endpoint, so that only the creator of the original document may register an errata related to this document. Now, the `POST` endpoint should be as so:

- Route: `/institution/{institutionId}/errata/create` (unchanged)
- Route parameter(s): `institutionId`
- Request body:

```json
{
  "description": "string",
  "documentId": 0,
  "healthcareProfessionalId": 0
}
```

# Changes made

- Added a filter that retrieves the healthcare professional ID from the request body of the `POST` endpoint.
- Added a custom document repository (with a query that uses the retrieved healthcare professional ID), and modified the service and controller layers.