### PR TITLE
Fix: reports pdf formatting & extract code duplicate

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/domain/service/QuestionnaireUtilsService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/domain/service/QuestionnaireUtilsService.java
@@ -1,0 +1,30 @@
+package net.pladema.questionnaires.common.domain.service;
+
+import net.pladema.person.repository.entity.Person;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class QuestionnaireUtilsService {
+
+	public String fullNameFromPerson(Person person) {
+
+		StringBuilder fullNameBuilder = new StringBuilder();
+
+		if (person.getLastName() != null) {
+			fullNameBuilder.append(person.getLastName()).append(" ");
+		}
+		if (person.getOtherLastNames() != null) {
+			fullNameBuilder.append(person.getOtherLastNames()).append(" ");
+		}
+		if (person.getFirstName() != null) {
+			fullNameBuilder.append(person.getFirstName()).append(" ");
+		}
+		if (person.getMiddleNames() != null) {
+			fullNameBuilder.append(person.getMiddleNames()).append(" ");
+		}
+
+		return fullNameBuilder.toString().trim();
+	}
+
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/domain/service/GetAllService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/domain/service/GetAllService.java
@@ -2,6 +2,8 @@ package net.pladema.questionnaires.general.getall.domain.service;
 
 import java.util.List;
 
+import net.pladema.questionnaires.common.domain.service.QuestionnaireUtilsService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -26,11 +28,15 @@ public class GetAllService {
 	@Autowired
 	private final PersonRepository personRepository;
 
-    public GetAllService(QuestionnaireResponseRepository questionnaireResponseRepository, HealthcareProfessionalRepository healthcareProfessionalRepository, PersonRepository personRepository) {
+	@Autowired
+	private final QuestionnaireUtilsService utilsService;
+
+    public GetAllService(QuestionnaireResponseRepository questionnaireResponseRepository, HealthcareProfessionalRepository healthcareProfessionalRepository, PersonRepository personRepository, QuestionnaireUtilsService utilsService) {
         this.questionnaireResponseRepository = questionnaireResponseRepository;
         this.healthcareProfessionalRepository = healthcareProfessionalRepository;
         this.personRepository = personRepository;
-    }
+		this.utilsService = utilsService;
+	}
 
 	public List<QuestionnaireResponse> getResponsesByPatientIdWithDetails(Integer patientId) {
 		Sort sort = Sort.by(Sort.Order.desc("id"));
@@ -48,22 +54,7 @@ public class GetAllService {
 		Person person = personRepository.findById(personId)
 				.orElseThrow(() -> new NotFoundException("Person not found"));
 
-		StringBuilder fullNameBuilder = new StringBuilder();
-
-		if (person.getLastName() != null) {
-			fullNameBuilder.append(person.getLastName()).append(" ");
-		}
-		if (person.getOtherLastNames() != null) {
-			fullNameBuilder.append(person.getOtherLastNames()).append(" ");
-		}
-		if (person.getFirstName() != null) {
-			fullNameBuilder.append(person.getFirstName()).append(" ");
-		}
-		if (person.getMiddleNames() != null) {
-			fullNameBuilder.append(person.getMiddleNames()).append(" ");
-		}
-
-		return fullNameBuilder.toString().trim();
+		return utilsService.fullNameFromPerson(person);
 	}
 
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getpdf/domain/service/GetQuestionnairePdfService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getpdf/domain/service/GetQuestionnairePdfService.java
@@ -143,21 +143,14 @@ public class GetQuestionnairePdfService {
 
 	public String formatAge(Period agePeriod) {
 		int years = agePeriod.getYears();
-		int months = agePeriod.getMonths();
 
 		StringBuilder formattedAge = new StringBuilder();
 
 		if (years > 0) {
 			formattedAge.append(years).append(" ").append(years == 1 ? "año" : "años");
 		}
-		if (months > 0) {
-			if (years > 0) {
-				formattedAge.append(", ");
-			}
-			formattedAge.append(months).append(" ").append(months == 1 ? "mes" : "meses");
-		}
 		if (formattedAge.length() == 0) {
-			formattedAge.append("Menos de un mes");
+			formattedAge.append("Menos de un año");
 		}
 
 		return formattedAge.toString();

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/edmonton_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/edmonton_reports.html
@@ -55,16 +55,16 @@
         <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
         <p>Institución: <span th:text="${institution.name}"></span></p>
         <hr></hr>
-        <h5>Detalles del paciente</h5>
+        <h5>Datos del paciente</h5>
         <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>
         <p><span th:utext="${'<b>' + patientIdType.description + ':</b> ' + patientPerson.identificationNumber}"></span></p>
         <p>Edad a la fecha de atención: <span th:text="${patientAge}"></span></p>
         <hr></hr>
-        <h5>Detalles del profesional</h5>
+        <h5>Datos del profesional</h5>
         <p>Apellido y nombre: <span th:text="${professionalPersonFullName}"></span></p>
-        <p>Licencia: <span th:text="${professional.licenseNumber}"></span></p>
+        <p>M.P.: <span th:text="${professional.licenseNumber}"></span></p>
 
-        <h3>Prueba de Edmonton (fragilidad) - Resultados de informe</h3>
+        <h3>Prueba de Edmonton (fragilidad) - Informe de resultados</h3>
 
         <hr></hr>
 

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/familybg_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/familybg_reports.html
@@ -50,16 +50,16 @@
         <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
         <p>Institución: <span th:text="${institution.name}"></span></p>
         <hr></hr>
-        <h5>Detalles del paciente</h5>
+        <h5>Datos del paciente</h5>
         <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>
         <p><span th:utext="${'<b>' + patientIdType.description + ':</b> ' + patientPerson.identificationNumber}"></span></p>
         <p>Edad a la fecha de atención: <span th:text="${patientAge}"></span></p>
         <hr></hr>
-        <h5>Detalles del profesional</h5>
+        <h5>Datos del profesional</h5>
         <p>Apellido y nombre: <span th:text="${professionalPersonFullName}"></span></p>
-        <p>Licencia: <span th:text="${professional.licenseNumber}"></span></p>
+        <p>M.P.: <span th:text="${professional.licenseNumber}"></span></p>
 
-        <h3>Cuestionario de antecedentes familiares - Resultados de informe</h3>
+        <h3>Cuestionario de antecedentes familiares - Informe de resultados</h3>
 
         <hr></hr>
 

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/frail_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/frail_reports.html
@@ -54,16 +54,16 @@
         <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
         <p>Institución: <span th:text="${institution.name}"></span></p>
         <hr></hr>
-        <h5>Detalles del paciente</h5>
+        <h5>Datos del paciente</h5>
         <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>
         <p><span th:utext="${'<b>' + patientIdType.description + ':</b> ' + patientPerson.identificationNumber}"></span></p>
         <p>Edad a la fecha de atención: <span th:text="${patientAge}"></span></p>
         <hr></hr>
-        <h5>Detalles del profesional</h5>
+        <h5>Datos del profesional</h5>
         <p>Apellido y nombre: <span th:text="${professionalPersonFullName}"></span></p>
-        <p>Licencia: <span th:text="${professional.licenseNumber}"></span></p>
+        <p>M.P.: <span th:text="${professional.licenseNumber}"></span></p>
 
-        <h3>Prueba de Frail (fragilidad) - Resultados de informe</h3>
+        <h3>Escala de Frail (fragilidad) - Informe de resultados</h3>
 
         <hr></hr>
 
@@ -137,14 +137,14 @@
 
         <div class="itemcontainer" th:each="respuesta : ${answers[3]}">
             <h4>Comorbilidad</h4>
-            <p>¿Alguna vez un médico le dijo que usted tiene: hipertensión, diabetes, cáncer (que no sea un cáncer de piel de menor importancia), enfermedad pulmonar crónica, ataque cardíaco, insuficiencia cardíaca congestiva, angina de pecho, asma, artritis, ictus y enfermedad renal? (cant. menor a 5 = 'No', cant. mayor o igual 5 = 'Sí')</p>
+            <p>¿Cuántas de las siguientes patologías le ha indicado un médico que usted tiene: hipertensión, diabetes, cáncer (que no sea un cáncer de piel de menor importancia), enfermedad pulmonar crónica, ataque cardíaco, insuficiencia cardíaca congestiva, angina de pecho, asma, artritis, ictus y enfermedad renal?</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt10" th:checked="${respuesta.answerId == 20}"></input>
-                Sí
+                Tiene 5 o más patologías
             </label><br></br>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt11" th:checked="${respuesta.answerId == 19}"></input>
-                No
+                Tiene menos de 5 patologías
             </label><br></br>
         </div>
 

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
@@ -50,16 +50,16 @@
         <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
         <p>Institución: <span th:text="${institution.name}"></span></p>
         <hr></hr>
-        <h5>Detalles del paciente</h5>
+        <h5>Datos del paciente</h5>
         <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>
         <p><span th:utext="${'<b>' + patientIdType.description + ':</b> ' + patientPerson.identificationNumber}"></span></p>
         <p>Edad a la fecha de atención: <span th:text="${patientAge}"></span></p>
         <hr></hr>
-        <h5>Detalles del profesional</h5>
+        <h5>Datos del profesional</h5>
         <p>Apellido y nombre: <span th:text="${professionalPersonFullName}"></span></p>
-        <p>Licencia: <span th:text="${professional.licenseNumber}"></span></p>
+        <p>M.P.: <span th:text="${professional.licenseNumber}"></span></p>
 
-        <h3>Prueba de desempeño físico de adulto mayor - Resultados de informe</h3>
+        <h3>Prueba de desempeño físico de adulto mayor - Informe de resultados</h3>
 
         <hr></hr>
 

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
@@ -43,6 +43,14 @@
            font-weight: normal;
         }
 
+        .bold-text {
+            font-weight: bold;
+        }
+
+        .hidden-checkbox {
+            visibility: hidden;
+        }
+
     </style>
 </head>
 <body th:fragment="physicalperformance">
@@ -65,7 +73,7 @@
 
         <div class="itemcontainer" th:each="respuesta : ${answers[0]}">
             <h4>Prueba de balance</h4>
-            <p>Párese con los pies uno al lado del otro: ¿mantuvo la posición al menos 10 segundos? si el participante no logró completarlo, finaliza la prueba de balance.</p>
+            <p>· Párese con los pies uno al lado del otro: ¿mantuvo la posición al menos 10 segundos? si el participante no logró completarlo, finaliza la prueba de balance.</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
                 Sí
@@ -88,7 +96,7 @@
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[2]}">
-            <p>Párese en posición semi tándem: ¿mantuvo la posición al menos 10 segundos? si el participante no logró completarlo, finaliza la prueba de balance.</p>
+            <p>· Párese en posición semi tándem: ¿mantuvo la posición al menos 10 segundos? si el participante no logró completarlo, finaliza la prueba de balance.</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
                 Sí
@@ -111,7 +119,7 @@
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[4]}">
-            <p>Párese en posición tándem: ¿mantuvo la posición al menos 10 segundos?</p>
+            <p>· Párese en posición tándem: ¿mantuvo la posición al menos 10 segundos?</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
                 Se niega
@@ -130,7 +138,7 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[6]}">
             <h4>Velocidad de marcha</h4>
             <p>En esta oportunidad, la prueba requiere medir el tiempo en segundos para la realización de la prueba de velocidad de marcha en una distancia de 4 metros.</p>
-            <p>Primera medición: tiempo requerido para recorrer la distancia. Si el participante no logra completarla, finaliza la prueba.</p>
+            <p>· Primera medición: tiempo requerido para recorrer la distancia. Si el participante no logra completarla, finaliza la prueba.</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
                 Se niega
@@ -145,7 +153,7 @@
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[8]}">
-            <p>Segunda medición: tiempo requerido para recorrer la distancia.</p>
+            <p>· Segunda medición: tiempo requerido para recorrer la distancia.</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
                 Se niega
@@ -163,7 +171,7 @@
 
         <div class="itemcontainer" th:each="respuesta : ${answers[10]}">
             <h4>Prueba de levantarse cinco veces de un asiento</h4>
-            <p>Prueba previa (no se califica): ¿el paciente se levanta sin apoyarse en sus brazos? si el participante no logra completarlo, finaliza la prueba.</p>
+            <p>· Prueba previa (no se califica): ¿el paciente se levanta sin apoyarse en sus brazos? si el participante no logra completarlo, finaliza la prueba.</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
                 Sí
@@ -179,7 +187,7 @@
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[11]}">
-            <p>Prueba de levantarse cinco veces repetidamente de una silla: ¿el participante puede levantarse cinco veces de la silla sin usar sus brazos?</p>
+            <p>· Prueba de levantarse cinco veces repetidamente de una silla: ¿el participante puede levantarse cinco veces de la silla sin usar sus brazos?</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
                 Sí
@@ -199,6 +207,23 @@
             <label>
                 <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
             </label>
+        </div>
+
+        <div class="itemcontainer" th:each="respuesta : ${answers[13]}">
+            <h4>Resultado de evaluación</h4>
+            <p>El puntaje total da como resultado:</p>
+            <label th:class="${respuesta.value == 'bajo'} ? 'bold-text' : ''">
+                <input type="checkbox" disabled="disabled" readonly="readonly"
+                       th:checked="${respuesta.value == 'bajo'}"
+                       th:classappend="${respuesta.value != 'bajo'} ? 'hidden-checkbox' : ''"></input>
+                Desempeño físico bajo
+            </label><br></br>
+            <label th:class="${respuesta.value == 'alto'} ? 'bold-text' : ''">
+                <input type="checkbox" disabled="disabled" readonly="readonly"
+                       th:checked="${respuesta.value == 'alto'}"
+                       th:classappend="${respuesta.value != 'alto'} ? 'hidden-checkbox' : ''"></input>
+                Desempeño físico alto
+            </label><br></br>
         </div>
 
         <hr></hr>


### PR DESCRIPTION
## Description

This PR introduces a few formatting improvements to the HTML templates used for the PDF generation of the questionnaires response, as well as extracting a duplicate method used for getting a patient's full name as a string.

## Changes

### 1. HTML template changes

- Change header fields "Detalles del paciente" and "Detalles del profesional" to "Datos del paciente" and "Datos del profesional" for all the questionnaires, respectively.
- Change header field "Licencia" to "M.P." (matrícula profesional) for all the questionnaires.
- Removes the "meses" detail of the patient's age in the header.
- Change questionnaire title from "Nombre del cuestionario - Resultados de informe" to ""Nombre del cuestionario - Informe de resultados" for all the questionnaires.
- In the FRAIL report, change syntax to more appropiate one for an item of the test for easier understanding.
- In the FRAIL report, add the assessment result section at the end. This implies the addition of 2 rows to `minsal_lr_item` table for the relevant item. @DocOc98 

### 2. Function duplicates extraction

- Create a small new `@Service` currently only used for sharing a function that generates a string with the full name from a `Person` object. This is consumed by the PDF and the 'get all questionnaires by patient' endpoints.

## Related issues

Closes #138 