### PR TITLE
Fix: questionnaires professional details' fetching

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/errata/common/dto/ErrataRequestDTO.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/common/dto/ErrataRequestDTO.java
@@ -15,6 +15,6 @@ public class ErrataRequestDTO {
 
 	private Integer documentId;
 
-	private Integer healthcareProfessionalId;
+	private Integer userId;
 
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/errata/general/endpoints/service/ErrataService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/errata/general/endpoints/service/ErrataService.java
@@ -29,7 +29,7 @@ public class ErrataService {
 			throw new RuntimeException("An errata already exists for the document with the ID " + requestDTO.getDocumentId());
 		}
 
-		boolean isAuthorized = customDocumentRepository.existsByIdAndCreatedByOrUpdatedBy(Long.valueOf(requestDTO.getDocumentId()), requestDTO.getHealthcareProfessionalId(), requestDTO.getHealthcareProfessionalId());
+		boolean isAuthorized = customDocumentRepository.existsByIdAndCreatedByOrUpdatedBy(Long.valueOf(requestDTO.getDocumentId()), requestDTO.getUserId(), requestDTO.getUserId());
 		if (!isAuthorized) {
 			throw new RuntimeException("You are not authorized to create an errata for document with ID " + requestDTO.getDocumentId());
 		}

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/domain/service/QuestionnaireUtilsService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/domain/service/QuestionnaireUtilsService.java
@@ -1,11 +1,32 @@
 package net.pladema.questionnaires.common.domain.service;
 
+import net.pladema.person.repository.PersonRepository;
 import net.pladema.person.repository.entity.Person;
 
+import net.pladema.staff.repository.HealthcareProfessionalRepository;
+import net.pladema.staff.repository.entity.HealthcareProfessional;
+import net.pladema.user.repository.UserPersonRepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class QuestionnaireUtilsService {
+
+	@Autowired
+	private final UserPersonRepository userPersonRepository;
+
+	@Autowired
+	private final PersonRepository personRepository;
+
+	@Autowired
+	private final HealthcareProfessionalRepository healthcareProfessionalRepository;
+
+	public QuestionnaireUtilsService(UserPersonRepository userPersonRepository, PersonRepository personRepository, HealthcareProfessionalRepository healthcareProfessionalRepository) {
+		this.userPersonRepository = userPersonRepository;
+		this.personRepository = personRepository;
+		this.healthcareProfessionalRepository = healthcareProfessionalRepository;
+	}
 
 	public String fullNameFromPerson(Person person) {
 
@@ -25,6 +46,24 @@ public class QuestionnaireUtilsService {
 		}
 
 		return fullNameBuilder.toString().trim();
+	}
+
+	public Person getPersonByUserId(Integer userId) {
+
+		Integer personId = userPersonRepository.getPersonIdByUserId(userId)
+				.orElseThrow(() -> new RuntimeException("Person id not found for user id " + userId));
+
+		return personRepository.findById(personId)
+				.orElseThrow(() -> new RuntimeException("Person not found for id " + personId));
+	}
+
+	public HealthcareProfessional getHealthcareProfessionalByUserId(Integer userId) {
+
+		Integer personId = userPersonRepository.getPersonIdByUserId(userId)
+				.orElseThrow(() -> new RuntimeException("Person id not found for user id " + userId));
+
+		return healthcareProfessionalRepository.findByPersonId(personId)
+				.orElseThrow(() -> new RuntimeException("HealthcareProfessional not found for person id " + personId));
 	}
 
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/repository/entity/QuestionnaireResponse.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/repository/entity/QuestionnaireResponse.java
@@ -109,20 +109,4 @@ public class QuestionnaireResponse extends SGXAuditableEntity<Integer> {
 		}
 	}
 
-	public String getCreatedByLicenseNumber() {
-		if (createdByHealthcareProfessional != null) {
-			return createdByHealthcareProfessional.getLicenseNumber();
-		} else  {
-			return null;
-		}
-	}
-
-	public String getUpdatedByLicenseNumber() {
-		if (updatedByHealthcareProfessional != null) {
-			return updatedByHealthcareProfessional.getLicenseNumber();
-		} else  {
-			return null;
-		}
-	}
-
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/controller/GetAllController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/controller/GetAllController.java
@@ -2,6 +2,9 @@ package net.pladema.questionnaires.general.getall.controller;
 
 import java.util.List;
 
+import net.pladema.person.repository.entity.Person;
+import net.pladema.questionnaires.common.domain.service.QuestionnaireUtilsService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,9 +31,13 @@ public class GetAllController {
 	@Autowired
 	private final GetAllService getAllService;
 
-    public GetAllController(GetAllService getAllService) {
+	@Autowired
+	private final QuestionnaireUtilsService utilsService;
+
+    public GetAllController(GetAllService getAllService, QuestionnaireUtilsService utilsService) {
         this.getAllService = getAllService;
-    }
+		this.utilsService = utilsService;
+	}
 
 	@PreAuthorize("hasPermission(#institutionId, 'ESPECIALISTA_MEDICO, PROFESIONAL_DE_SALUD, ENFERMERO_ADULTO_MAYOR, ENFERMERO, ESPECIALISTA_EN_ODONTOLOGIA')")
 	@GetMapping("institution/{institutionId}/patient/{patientId}/all-questionnaire-responses")
@@ -43,11 +50,11 @@ public class GetAllController {
 
 			for (QuestionnaireResponse response : responses) {
 
-				Integer createdByHealthcareProfessionalId = response.getCreatedBy();
-				Integer updatedByHealthcareProfessionalId = response.getUpdatedBy();
+				Person createdByPerson = utilsService.getPersonByUserId(response.getCreatedBy());
+				Person updatedByPerson = utilsService.getPersonByUserId(response.getUpdatedBy());
 
-				String createdByHealthcareProfessionalFullName = getAllService.getFullNameByHealthcareProfessionalId(createdByHealthcareProfessionalId);
-				String updatedByHealthcareProfessionalFullName = getAllService.getFullNameByHealthcareProfessionalId(updatedByHealthcareProfessionalId);
+				String createdByHealthcareProfessionalFullName = utilsService.fullNameFromPerson(createdByPerson);
+				String updatedByHealthcareProfessionalFullName = utilsService.fullNameFromPerson(updatedByPerson);
 
 				response.setCreatedByFullName(createdByHealthcareProfessionalFullName);
 				response.setUpdatedByFullName(updatedByHealthcareProfessionalFullName);

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/controller/GetAllController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/controller/GetAllController.java
@@ -5,6 +5,8 @@ import java.util.List;
 import net.pladema.person.repository.entity.Person;
 import net.pladema.questionnaires.common.domain.service.QuestionnaireUtilsService;
 
+import net.pladema.staff.repository.entity.HealthcareProfessional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,11 +55,17 @@ public class GetAllController {
 				Person createdByPerson = utilsService.getPersonByUserId(response.getCreatedBy());
 				Person updatedByPerson = utilsService.getPersonByUserId(response.getUpdatedBy());
 
+				HealthcareProfessional createdByProfessional = utilsService.getHealthcareProfessionalByUserId(response.getCreatedBy());
+				HealthcareProfessional updatedByProfessional = utilsService.getHealthcareProfessionalByUserId(response.getUpdatedBy());
+
 				String createdByHealthcareProfessionalFullName = utilsService.fullNameFromPerson(createdByPerson);
 				String updatedByHealthcareProfessionalFullName = utilsService.fullNameFromPerson(updatedByPerson);
 
 				response.setCreatedByFullName(createdByHealthcareProfessionalFullName);
 				response.setUpdatedByFullName(updatedByHealthcareProfessionalFullName);
+
+				response.setCreatedByLicenseNumber(createdByProfessional.getLicenseNumber());
+				response.setUpdatedByLicenseNumber(updatedByProfessional.getLicenseNumber());
 			}
 			return new ResponseEntity<>(responses, HttpStatus.OK);
 		} catch (Exception e) {

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/domain/service/GetAllService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getall/domain/service/GetAllService.java
@@ -44,17 +44,4 @@ public class GetAllService {
 		return questionnaireResponseRepository.findResponsesWithCreatedByDetails(patientId, sort);
 	}
 
-	public String getFullNameByHealthcareProfessionalId(Integer healthcareProfessionalId) {
-
-		HealthcareProfessional healthcareProfessional = healthcareProfessionalRepository.findById(healthcareProfessionalId)
-				.orElseThrow(() -> new NotFoundException("HealthcareProfessional not found"));
-
-		Integer personId = healthcareProfessional.getPersonId();
-
-		Person person = personRepository.findById(personId)
-				.orElseThrow(() -> new NotFoundException("Person not found"));
-
-		return utilsService.fullNameFromPerson(person);
-	}
-
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getpdf/domain/service/GetQuestionnairePdfService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getpdf/domain/service/GetQuestionnairePdfService.java
@@ -70,12 +70,9 @@ public class GetQuestionnairePdfService {
 
 		List<Answer> answers = answerRepository.findByQuestionnaireResponseId(questionnaireResponseId);
 
-		HealthcareProfessional professional = healthcareProfessionalRepository.findById(response.getCreatedBy())
-				.orElseThrow(() -> new NotFoundException("HealthcareProfessional not found"));
+		HealthcareProfessional professional = utilsService.getHealthcareProfessionalByUserId(response.getCreatedBy());
 
-		Integer professionalPersonId = professional.getPersonId();
-
-		Person professionalPerson = personRepository.findById(professionalPersonId)
+		Person professionalPerson = personRepository.findById(professional.getPersonId())
 				.orElseThrow(() -> new NotFoundException("Healthcare professional person not found"));
 
 		Institution institution = institutionRepository.findById(institutionId)


### PR DESCRIPTION
## Description

This pull request introduces the following 4 changes to the API:

1. Change a variable name in the **Errata** request DTO to better reflect the parameter usage.
2. Fix the population of the context hashmap being used to populate the HTML templates of the questionnaires, specially the **healthcare professional name and their license number** (used in the download as PDF endpoint).
3. Fix the 'get all questionnaire responses' endpoint to properly expose the related **healthcare professional's details**.

## Technical details

For the previously stated changes, specifically:

1. The JSON request payload for the `POST` (create) errata endpoint now will look like this:

```json
{
  "description": "string",
  "documentId": 0,
  "userId": 0
}
```

for further details of the errata feature, take a look at #113 and #121.

3. The JSON response payload for the `GET` 'all questionnaire responses' endpoint now will look as follows (only changes the name of variables):

```json
[
  {
    "id": 127,
    "statusId": 2,
    "createdByFullName": "CIANCI HUMBERTO PRIMO",
    "createdByLicenseNumber": "111",
    "updatedByFullName": "CIANCI HUMBERTO PRIMO",
    "updatedByLicenseNumber": "111",
    "questionnaireTypeId": 4,
    "questionnaireType": "Prueba de Desempeño Físico del Adulto Mayor",
    "deleted": false,
    "updatedOn": "2024-05-17T13:52:44.608Z",
    "createdOn": "2024-05-17T13:52:44.608Z"
  },
  ... (other response objects)
]
```

route and route parameters are left untouched.

## Related issues

@Barbara-Alvarez 

## Related developers

@RodrigoCba96 
@cquevedox 