### PR TITLE
Feat: modify final sections of assessments HTML template to be the same

### DIFF
--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/edmonton_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/edmonton_reports.html
@@ -248,23 +248,27 @@
         <br></br>
 
         <div class="itemcontainer" th:each="respuesta : ${answers[11]}">
-            <h4>Total</h4>
-            <p>El puntaje final de la prueba realizada se interpreta como:</p>
+            <h4>Resultado de evaluación</h4>
+            <p>
+                <span class="bold-text">El puntaje final de la prueba es: </span>
+                <span style="font-weight: normal;" th:text="${respuesta.value + ' puntos'}">[PUNTUACIÓN]</span>
+            </p>
+            <p>Que se interpreta como:</p>
             <label th:class="${respuesta.answerId == 21} ? 'bold-text' : ''">
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt29" th:checked="${respuesta.answerId == 21}"></input>
-                4 o menor: individuo sano
+                0 - 4: individuo sano
             </label><br></br>
             <label th:class="${respuesta.answerId == 22} ? 'bold-text' : ''">
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt30" th:checked="${respuesta.answerId == 22}"></input>
-                5 o 6: vulnerable
+                5 - 6: vulnerable
             </label><br></br>
             <label th:class="${respuesta.answerId == 23} ? 'bold-text' : ''">
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt31" th:checked="${respuesta.answerId == 23}"></input>
-                7 u 8: fragilidad leve
+                7 - 8: fragilidad leve
             </label><br></br>
             <label th:class="${respuesta.answerId == 24} ? 'bold-text' : ''">
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt32" th:checked="${respuesta.answerId == 24}"></input>
-                9 o 10: fragilidad moderada
+                9 - 10: fragilidad moderada
             </label><br></br>
             <label th:class="${respuesta.answerId == 25} ? 'bold-text' : ''">
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt33" th:checked="${respuesta.answerId == 25}"></input>

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/frail_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/frail_reports.html
@@ -166,15 +166,19 @@
         <hr></hr>
 
         <div class="itemcontainer" th:each="respuesta : ${answers[5]}">
-            <h4>Interpretación de puntaje</h4>
-            <p>La sumatoria da como resultado</p>
+            <h4>Resultado de evaluación</h4>
+            <p>
+                <span class="bold-text">El puntaje final de la prueba es: </span>
+                <span style="font-weight: normal;" th:text="${respuesta.value + ' puntos'}">[PUNTUACIÓN]</span>
+            </p>
+            <p>Que se interpreta como:</p>
             <label th:class="${respuesta.answerId == 49} ? 'bold-text' : ''">
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt14" th:checked="${respuesta.answerId == 49}"></input>
-                0 a 2 - persona pre-frágil
+                0 - 2: persona pre-frágil
             </label><br></br>
             <label th:class="${respuesta.answerId == 50} ? 'bold-text' : ''">
                 <input type="checkbox" disabled="disabled" readonly="readonly" name="opt15" th:checked="${respuesta.answerId == 50}"></input>
-                3 a 5 - persona frágil
+                3 - 5: persona frágil
             </label><br></br>
         </div>
         <br></br>

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
@@ -47,10 +47,6 @@
             font-weight: bold;
         }
 
-        .hidden-checkbox {
-            visibility: hidden;
-        }
-
     </style>
 </head>
 <body th:fragment="physicalperformance">
@@ -121,7 +117,7 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[4]}">
             <p>· Párese en posición tándem: ¿mantuvo la posición al menos 10 segundos?</p>
             <label>
-                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
                 Se niega
             </label><br></br>
         </div>
@@ -140,7 +136,7 @@
             <p>En esta oportunidad, la prueba requiere medir el tiempo en segundos para la realización de la prueba de velocidad de marcha en una distancia de 4 metros.</p>
             <p>· Primera medición: tiempo requerido para recorrer la distancia. Si el participante no logra completarla, finaliza la prueba.</p>
             <label>
-                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
                 Se niega
             </label><br></br>
         </div>
@@ -155,7 +151,7 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[8]}">
             <p>· Segunda medición: tiempo requerido para recorrer la distancia.</p>
             <label>
-                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 44}"></input>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
                 Se niega
             </label><br></br>
         </div>
@@ -211,24 +207,24 @@
 
         <div class="itemcontainer" th:each="respuesta : ${answers[13]}">
             <h4>Resultado de evaluación</h4>
-            <p>El puntaje total da como resultado:</p>
-            <label th:class="${respuesta.value == 'bajo'} ? 'bold-text' : ''">
-                <input type="checkbox" disabled="disabled" readonly="readonly"
-                       th:checked="${respuesta.value == 'bajo'}"
-                       th:classappend="${respuesta.value != 'bajo'} ? 'hidden-checkbox' : ''"></input>
-                Desempeño físico bajo
+            <p>
+                <span class="bold-text">El puntaje final de la prueba es: </span>
+                <span style="font-weight: normal;" th:text="${respuesta.value + ' puntos'}">[PUNTUACIÓN]</span>
+            </p>
+            <p>Que se interpreta como:</p>
+            <label th:class="${respuesta.answerId == 52} ? 'bold-text' : ''">
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 52}"></input>
+                0 - 7: Desempeño físico bajo
             </label><br></br>
-            <label th:class="${respuesta.value == 'alto'} ? 'bold-text' : ''">
-                <input type="checkbox" disabled="disabled" readonly="readonly"
-                       th:checked="${respuesta.value == 'alto'}"
-                       th:classappend="${respuesta.value != 'alto'} ? 'hidden-checkbox' : ''"></input>
-                Desempeño físico alto
+            <label th:class="${respuesta.answerId == 53} ? 'bold-text' : ''">
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 53}"></input>
+                8 - 12: Desempeño físico alto
             </label><br></br>
         </div>
 
         <hr></hr>
 
-        <p style="text-align: right; margin-top: 3em;">2/2</p>
+        <p style="text-align: right; margin-top: 2.5em;">2/2</p>
 
     </div>
     <!-- Bootstrap's script -->


### PR DESCRIPTION
## Descripción

Este pull request introduce los siguientes cambios a la API:

1. Modificación de las secciones de **Resultado de evaluación** de las plantillas HTML para la generación y descarga de los archivos PDF de los cuestionarios.
2. Adición respectiva de cuatro registros a la base de datos que reflejan estos cambios, respectivamente 2 por tabla a las siguientes tablas:
- `minsal_lr_option` y 
- `minsal_lr_item_option`.

## Cambios

### 1

Este cambio normaliza las secciones finales de todos los cuestionarios a la hora de descarga sus PDF. También se corrigieron algunas `id` en la plantilla del cuestionario de **Desempeño físico de adulto mayor**.

### 2

Este cambio surge a raíz del cambio anterior, y es la creación de registros que permitan impactar el resultado de evaluación final, tanto la puntuación como la opción determinada en base a la puntuación.

Para replicarlo se pueden correr los siguientes comandos en la base de datos (ya hice esto en testing @cquevedox):

```pgsql
INSERT INTO minsal_lr_option (value) VALUES ('Desempeño físico bajo'), ('Desempeño físico alto');
```

```pgsql
INSERT INTO minsal_lr_item_option (item_id, option_id) VALUES (88, 52), (88,53);
```