### PR TITLE
[Feature] add dialog alert for 'Adulto Mayor' questionnaires

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/ambulatoria.module.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/ambulatoria.module.ts
@@ -108,6 +108,7 @@ import { DesempenoFisicoComponent } from './components/cuestionarios/desempeno-f
 import { InputDesempenoComponent } from './components/cuestionarios/desempeno-fisico/input-desempeno/input-desempeno.component';
 import { GetEdmontonComponent } from './components/cuestionarios/edmonton/get-edmonton/get-edmonton.component';
 import { GetPhysicalPerformanceComponent } from './components/cuestionarios/desempeno-fisico/get-physical-performance/get-physical-performance.component';
+import { AlertDialogComponent } from './components/cuestionarios/alert-dialog/alert-dialog.component';
 
 @NgModule({
 	declarations: [
@@ -195,7 +196,8 @@ import { GetPhysicalPerformanceComponent } from './components/cuestionarios/dese
 		DesempenoFisicoComponent,
 		InputDesempenoComponent,
 		GetEdmontonComponent,
-		GetPhysicalPerformanceComponent
+		GetPhysicalPerformanceComponent,
+		AlertDialogComponent
 
 	],
 	imports: [

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/alert-dialog/alert-dialog.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/alert-dialog/alert-dialog.component.html
@@ -1,0 +1,9 @@
+<div class="center-dialog">
+    <mat-icon color="primary" class="alert-icon">error_outline</mat-icon>
+</div>
+<div mat-dialog-content class="alert-message">
+    <span>{{ data.message }}</span>
+</div>
+<div mat-dialog-actions class="center-dialog">
+    <button mat-raised-button color="primary" (click)="onClose()">Cerrar</button>
+</div>

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/alert-dialog/alert-dialog.component.scss
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/alert-dialog/alert-dialog.component.scss
@@ -1,0 +1,17 @@
+.center-dialog {
+    display: flex;
+    justify-content: center;
+    text-align: center;
+}
+
+.alert-icon {
+    width: 65px;
+    height: 65px;
+    font-size: 64px;
+}
+
+.alert-message {
+    padding-top: 10px;
+    padding-bottom: 2px;
+    font-size: 16px;
+}

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/alert-dialog/alert-dialog.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/alert-dialog/alert-dialog.component.ts
@@ -1,0 +1,20 @@
+import { Component, Inject } from "@angular/core";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+
+@Component({
+    selector: 'app-alert-dialog',
+    templateUrl: './alert-dialog.component.html',
+    styleUrls: ['./alert-dialog.component.scss'],
+})
+export class AlertDialogComponent {
+
+    constructor(
+        public dialogRef: MatDialogRef<AlertDialogComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: { message: string }
+    ) {}
+
+    onClose(): void {
+        this.dialogRef.close();
+    }
+
+}

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/desempeno-fisico/get-physical-performance/get-physical-performance.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/desempeno-fisico/get-physical-performance/get-physical-performance.component.ts
@@ -1,16 +1,16 @@
 import { Inject, Component, OnInit } from '@angular/core';
 import { PhysicalPerformanceService } from '@api-rest/services/physical-performance.service';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { QuestionnairesResponses } from '@api-rest/api-model';
+import { AlertDialogComponent } from '../../alert-dialog/alert-dialog.component';
  
 @Component({
   selector: 'app-get-physical-performance',
   templateUrl: './get-physical-performance.component.html',
   styleUrls: ['./get-physical-performance.component.scss']
 })
-export class GetPhysicalPerformanceComponent implements OnInit {
 
-  
+export class GetPhysicalPerformanceComponent implements OnInit {  
   submitted: boolean;
   patientId: number;
   physicalQuestionnaires: QuestionnairesResponses[] = [];
@@ -19,6 +19,7 @@ export class GetPhysicalPerformanceComponent implements OnInit {
   constructor(
     private PhysicalPerformanceService: PhysicalPerformanceService,
     @Inject(MAT_DIALOG_DATA) public data: any,
+    private dialog: MatDialog
   ) {
 
     this.patientId = data.patientId
@@ -43,7 +44,6 @@ export class GetPhysicalPerformanceComponent implements OnInit {
       (questionnaire) => questionnaire.questionnaireTypeId === 4
     );
 
-
     // Sort by creation date
     physicalQuestionnaires.sort((a, b) => {
       return new Date(b.createdOn).getTime() - new Date(a.createdOn).getTime();
@@ -55,6 +55,7 @@ export class GetPhysicalPerformanceComponent implements OnInit {
       this.lastPhysicalQuestionnaireId = physicalQuestionnaires[0].id;
     } else {
       console.warn('No frail questionnaires found for this patient')
+      this.showAlert('No hay cuestionarios disponibles para este paciente.')
     }
   }
 
@@ -69,10 +70,19 @@ export class GetPhysicalPerformanceComponent implements OnInit {
         },
         (error) => {
           console.error('Error downloading the questionnaire PDF:', error);
+          this.showAlert('No hay cuestionarios disponibles para este paciente.')
         }
       );
     } else {
       console.warn('No Frail questionnaires available to download PDF.')
+      this.showAlert('No hay cuestionarios disponibles para este paciente.')
     }
   }
+
+  showAlert(message: string): void {
+    this.dialog.open(AlertDialogComponent, {
+      data: { message: message }
+    });
+  }
+
 }

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/edmonton/get-edmonton/get-edmonton.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/edmonton/get-edmonton/get-edmonton.component.ts
@@ -1,7 +1,8 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { EdmontonService } from '@api-rest/services/edmonton.service';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { QuestionnairesResponses } from '@api-rest/api-model';
+import { AlertDialogComponent } from '../../alert-dialog/alert-dialog.component';
 
 @Component({
   selector: 'app-get-edmonton',
@@ -18,6 +19,7 @@ export class GetEdmontonComponent implements OnInit {
   constructor(
     private EdmontonService: EdmontonService,
     @Inject(MAT_DIALOG_DATA) public data: any,
+    private dialog: MatDialog
   ) {
 
     this.patientId = data.patientId
@@ -52,6 +54,7 @@ export class GetEdmontonComponent implements OnInit {
       this.lastEdmontonQuestionnaireId = edmontonQuestionnaires[0].id;
     } else {
       console.warn('No frail questionnaires found for this patient')
+      this.showAlert('No hay cuestionarios disponibles para este paciente.')
     }
   }
 
@@ -66,10 +69,19 @@ export class GetEdmontonComponent implements OnInit {
         },
         (error) => {
           console.error('Error downloading the questionnaire PDF:', error);
+          this.showAlert('Error al descargar el PDF del cuestionario.');
         }
       );
     } else {
       console.warn('No Frail questionnaires available to download PDF.')
+      this.showAlert('No hay cuestionarios disponibles para descargar.')
     }
   }
+
+  showAlert(message: string): void {
+    this.dialog.open(AlertDialogComponent, {
+      data: { message: message },
+    });
+  }
+
 }

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/get-frail/get-frail.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/frail-scale/get-frail/get-frail.component.ts
@@ -1,7 +1,8 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FrailService } from '@api-rest/services/fragility-test.service';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { QuestionnairesResponses } from '@api-rest/api-model';
+import { AlertDialogComponent } from '../../alert-dialog/alert-dialog.component';
 
 @Component({
   selector: 'app-get-frail',
@@ -19,6 +20,7 @@ export class GetFrailComponent implements OnInit {
   constructor(
     private frailService: FrailService,
     @Inject(MAT_DIALOG_DATA) public data: any,
+    private dialog: MatDialog
   ) {
 
     this.patientId = data.patientId
@@ -53,6 +55,7 @@ export class GetFrailComponent implements OnInit {
       this.lastFrailQuestionnaireId = frailQuestionnaires[0].id;
     } else {
       console.warn('No frail questionnaires found for this patient')
+      this.showAlert('No hay cuestionarios disponibles para este paciente.')
     }
   }
 
@@ -67,10 +70,19 @@ export class GetFrailComponent implements OnInit {
         },
         (error) => {
           console.error('Error downloading the questionnaire PDF:', error);
+          this.showAlert('Error al descargar el PDF del cuestionario.');
         }
       );
     } else {
       console.warn('No Frail questionnaires available to download PDF.')
+      this.showAlert('No hay cuestionarios disponibles para descargar.')
     }
   }
+
+  showAlert(message: string): void {
+    this.dialog.open(AlertDialogComponent, {
+      data: { message: message },
+    });
+  }
+
 }


### PR DESCRIPTION
## Descripción del cambio.
Se creó una alerta para la descarga de cuestionarios de Adulto Mayor. Esta alerta está diseñada para los casos en los que se quiera descargar un cuestionario de un paciente que aún no tiene registrado ninguno de estos en la base de datos.

### Cambios realizados.
- Se agregó un componente de alerta para la descarga de cuestionarios de Adulto Mayor.
- Se integró la alerta a los siguientes componentes:
  - get-frail component.
  - get-edmonton component.
  - get-physical-performance component.

### Issues relacionadas.
Sin issues relacionadas.