### PR TITLE
Fix result in desempeño fisico

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/desempeno-fisico/desempeno-fisico.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/desempeno-fisico/desempeno-fisico.component.html
@@ -258,8 +258,8 @@
                 <div class="text">
                      <p id="70">La sumatoria da como resultado:</p>
                     <mat-radio-group id="88" name="points" [(ngModel)]="selectedCalificacion">
-                      <p color="primary"[style.color]="(selectedCalificacion === 'F1') ? '#2687c5' : 'darkgray'" [style.font-weight]="(selectedCalificacion === 'F1') ? '550' : 'normal'" id="49" value="F1">- DESEMPEÑO FISICO BAJO</p>
-                      <p color="primary" [style.color]="(selectedCalificacion === 'F2') ? '#2687c5' : 'darkgray'" [style.font-weight]="(selectedCalificacion === 'F2') ? '550' : 'normal'"  id="50" value="F2">- DESEMPEÑO FISICO ALTO</p>
+                      <p color="primary"[style.color]="(selectedCalificacion === 'F1') ? '#2687c5' : 'darkgray'" [style.font-weight]="(selectedCalificacion === 'F1') ? '550' : 'normal'" id="52" value="F1">- DESEMPEÑO FISICO BAJO</p>
+                      <p color="primary" [style.color]="(selectedCalificacion === 'F2') ? '#2687c5' : 'darkgray'" [style.font-weight]="(selectedCalificacion === 'F2') ? '550' : 'normal'"  id="53" value="F2">- DESEMPEÑO FISICO ALTO</p>
                     </mat-radio-group>
 
             </div>

--- a/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/desempeno-fisico/desempeno-fisico.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/historia-clinica/modules/ambulatoria/components/cuestionarios/desempeno-fisico/desempeno-fisico.component.ts
@@ -363,8 +363,8 @@ export class DesempenoFisicoComponent implements OnInit {
 
   calculoMapping() {
     const scoreMapping = {
-      'F1': "bajo",
-      'F2': "alto",
+      'F1': 52,
+      'F2': 53,
     }
     return scoreMapping[this.selectedCalificacion] || undefined;
   }
@@ -454,8 +454,8 @@ export class DesempenoFisicoComponent implements OnInit {
 
         {
           "itemId": 88,
-          "optionId": totalScore,
-          "value": this.calculoMapping(),
+          "optionId": this.calculoMapping(),
+          "value": totalScore,
         },
 
 


### PR DESCRIPTION
 Se realizó el update en la id que envia los resultados "desempeño fisico alto" y "desempeño fisico bajo" en GET PDF

#### Ahora cuando se visualiza el pdf creado, el resultado final se representa de la siguiente manera: 

![image](https://github.com/Historia-Clinica-La-Rioja/historia_clinica_LR/assets/113396981/e2022611-0a05-444d-af83-d58de6fc5a1b)
