### PR TITLE
fix: add autofill to PDFs where values aren't received and checkboxes…

### DIFF
--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/familybg_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/familybg_reports.html
@@ -351,14 +351,14 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[16]}">
             <p>Horas diarias afuera de casa</p>
             <label>
-                <p style="font-weight: normal;" th:text="${answers[16].value}" name="opt50"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != 0 ? respuesta.value + ' horas' : 'No registrado'}" name="opt50"></p>
             </label>
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[17]}">
             <p>Edad (años)</p>
             <label>
-                <p style="font-weight: normal;" th:text="${answers[17].value}" name="opt51"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != 0 ? respuesta.value + ' años' : 'No registrado'}" name="opt51"></p>
             </label><br></br>
         </div>
         <hr></hr>
@@ -403,14 +403,14 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[20]}">
             <p>Horas diarias afuera de casa</p>
             <label>
-                <p style="font-weight: normal;" th:text="${answers[20].value}" name="opt58"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != 0 ? respuesta.value + ' horas' : 'No registrado'}" name="opt58"></p>
             </label><br></br>
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[21]}">
             <p>Edad (años)</p>
             <label>
-                <p style="font-weight: normal;" th:text="${respuesta.value}" name="opt59"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != 0 ? respuesta.value + ' años' : 'No registrado'}" name="opt59"></p>
             </label><br></br>
         </div>
         <hr></hr>
@@ -440,14 +440,14 @@
             <h4>Hermanos</h4>
             <p>Vivos</p>
             <label>
-                <p style="font-weight: normal;" th:text="${answers[23].value}" name="opt64"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != 0 ? respuesta.value : 'No registrado'}" name="opt64"></p>
             </label><br></br>
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[24]}">
             <p>Fallecidos</p>
             <label>
-                <p style="font-weight: normal;" th:text="${answers[24].value}" name="opt65"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != 0 ? respuesta.value : 'No registrado'}" name="opt65"></p>
             </label><br></br>
         </div>
 
@@ -457,7 +457,7 @@
             <h4>Vivienda</h4>
             <p>Número de cuartos</p>
             <label>
-                <p style="font-weight: normal;" th:text="${answers[25].value}" name="opt66"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != 0 ? respuesta.value : 'No registrado'}" name="opt66"></p>
             </label><br></br>
         </div>
         <hr></hr>

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
@@ -69,7 +69,7 @@
 
         <div class="itemcontainer" th:each="respuesta : ${answers[0]}">
             <h4>Prueba de balance</h4>
-            <p>· Párese con los pies uno al lado del otro: ¿mantuvo la posición al menos 10 segundos? si el participante no logró completarlo, finaliza la prueba de balance.</p>
+            <p>· Párese con los pies uno al lado del otro: ¿mantuvo la posición al menos 10 segundos? Si el participante no logró completarlo, finaliza la prueba de balance.</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
                 Sí
@@ -87,12 +87,12 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[1]}">
             <p>Tiempo registrado (segundos)</p>
             <label>
-                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != '' and respuesta.value != '0' ? respuesta.value + ' s.' : 'No registrado'}"></p>
             </label>
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[2]}">
-            <p>· Párese en posición semi tándem: ¿mantuvo la posición al menos 10 segundos? si el participante no logró completarlo, finaliza la prueba de balance.</p>
+            <p>· Párese en posición semi tándem: ¿mantuvo la posición al menos 10 segundos? Si el participante no logró completarlo, finaliza la prueba de balance.</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
                 Sí
@@ -110,12 +110,16 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[3]}">
             <p>Tiempo registrado (segundos)</p>
             <label>
-                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != '' and respuesta.value != '0' ? respuesta.value + ' s.' : 'No registrado'}"></p>
             </label>
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[4]}">
-            <p>· Párese en posición tándem: ¿mantuvo la posición al menos 10 segundos?</p>
+            <p>· Párese en posición tándem: si el paciente accede a realizar la prueba, el tiempo registrado se ve posteriormente. </p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId != 51}"></input>
+                Accede a la prueba
+            </label><br></br>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
                 Se niega
@@ -125,16 +129,20 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[5]}">
             <p>Tiempo registrado (segundos)</p>
             <label>
-                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != '' and respuesta.value != '0' ? respuesta.value + ' s.' : 'No registrado'}"></p>
             </label>
         </div>
 
-        <p style="text-align: right; margin-top: 3em;">1/2</p>
+        <p style="text-align: right; margin-top: 1em;">1/2</p>
 
         <div class="itemcontainer" th:each="respuesta : ${answers[6]}">
             <h4>Velocidad de marcha</h4>
-            <p>En esta oportunidad, la prueba requiere medir el tiempo en segundos para la realización de la prueba de velocidad de marcha en una distancia de 4 metros.</p>
+            <p>La prueba requiere medir el tiempo en segundos para la realización de la prueba de velocidad de marcha en una distancia de 4 metros.</p>
             <p>· Primera medición: tiempo requerido para recorrer la distancia. Si el participante no logra completarla, finaliza la prueba.</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId != 51}"></input>
+                Accede a la prueba
+            </label><br></br>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
                 Se niega
@@ -144,12 +152,16 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[7]}">
             <p>Tiempo registrado (segundos)</p>
             <label>
-                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}" ></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != '' and respuesta.value != '0' ? respuesta.value + ' s.' : 'No registrado'}"></p>
             </label>
         </div>
         <hr></hr>
         <div class="itemcontainer" th:each="respuesta : ${answers[8]}">
             <p>· Segunda medición: tiempo requerido para recorrer la distancia.</p>
+            <label>
+                <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId != 51}"></input>
+                Accede a la prueba
+            </label><br></br>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 51}"></input>
                 Se niega
@@ -159,7 +171,7 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[9]}">
             <p>Tiempo registrado (segundos)</p>
             <label>
-                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != '' and respuesta.value != '0' ? respuesta.value + ' s.' : 'No registrado'}"></p>
             </label>
         </div>
         
@@ -167,7 +179,7 @@
 
         <div class="itemcontainer" th:each="respuesta : ${answers[10]}">
             <h4>Prueba de levantarse cinco veces de un asiento</h4>
-            <p>· Prueba previa (no se califica): ¿el paciente se levanta sin apoyarse en sus brazos? si el participante no logra completarlo, finaliza la prueba.</p>
+            <p>· Prueba previa (no se califica): ¿el paciente se levanta sin apoyarse en sus brazos? Si el participante no logra completarlo, finaliza la prueba.</p>
             <label>
                 <input type="checkbox" disabled="disabled" readonly="readonly" th:checked="${respuesta.answerId == 20}"></input>
                 Sí
@@ -201,11 +213,11 @@
         <div class="itemcontainer" th:each="respuesta : ${answers[12]}">
             <p>Tiempo registrado (segundos)</p>
             <label>
-                <p style="font-weight: normal;" th:text="${respuesta.value + ' s.'}"></p>
+                <p style="font-weight: normal;" th:text="${respuesta.value != null and respuesta.value != '' and respuesta.value != '0' ? respuesta.value + ' s.' : 'No registrado'}"></p>
             </label>
         </div>
 
-        <div class="itemcontainer" th:each="respuesta : ${answers[13]}">
+        <div class="itemcontainer" style="margin-top: 13em;" th:each="respuesta : ${answers[13]}">
             <h4>Resultado de evaluación</h4>
             <p>
                 <span class="bold-text">El puntaje final de la prueba es: </span>
@@ -224,7 +236,7 @@
 
         <hr></hr>
 
-        <p style="text-align: right; margin-top: 2.5em;">2/2</p>
+        <p style="text-align: right;">2/2</p>
 
     </div>
     <!-- Bootstrap's script -->


### PR DESCRIPTION
… for clarification

## Contexto

Los cuestionarios al almacenar respuetas con values del tipo `null` en la base de datos, los muestran tal cual en los PDF a imprimir. Además el cuestionario de desempeño físico no tiene ítems para indicar que el paciente SI realiza la prueba (solo tiene ítems de **se rehúsa** o **se niega**), por lo que se agrega un falso ítem "Accede a la prueba" a la plantilla, que se checkea cuando el `optionId` no es **53** (que es cuando se rehúsa).

## Descripción

Este PR soluciona lo anterior agregando el texto "**No registrado**" para las respuestas donde no se anotó el tiempo (se anotó un tiempo con valor "0") para **desempeño físico**, y para las respuestas con valores numéricos en **antecedentes familiares**. También agrega el ítem "**Accede a la prueba**" para mejor interpretación de las secciones. El

## Cambios en el código fuente

Modifica las plantillas **HTML** de los **PDFs** para añadir los cambios de condiciones lógicas necesarios.

## Información adicional

Esto requiere que desde el frontend, al registrar cuestionarios donde el paciente si accede a realizar las pruebas, se envíe un valor diferente a **51** (podría ser 0 para estandarizar) para `optionId` en las respuestas (revisar la **wiki** por las dudas), que es la opción que indica que el paciente no realiza la prueba. @RodrigoCba96 

## Issues relacionados

- Closes #160 
- Closes #162 