### PR TITLE
Feat: institution in questionnaire & medicines prescription report title

### DIFF
--- a/back-end/app/src/main/resources/application-dev.properties
+++ b/back-end/app/src/main/resources/application-dev.properties
@@ -2,7 +2,7 @@
 # Parametros obligatorios
 # =============================================================================
 ## Conexion a la DB
-spring.datasource.url=jdbc:postgresql://localhost:5432/hospitalDB
+spring.datasource.url=jdbc:postgresql://localhost:55000/hospitalDB2
 spring.datasource.username=postgres
 spring.datasource.password=Local123
 

--- a/back-end/app/src/main/resources/application-dev.properties
+++ b/back-end/app/src/main/resources/application-dev.properties
@@ -2,7 +2,7 @@
 # Parametros obligatorios
 # =============================================================================
 ## Conexion a la DB
-spring.datasource.url=jdbc:postgresql://localhost:55000/hospitalDB2
+spring.datasource.url=jdbc:postgresql://localhost:5432/hospitalDB
 spring.datasource.username=postgres
 spring.datasource.password=Local123
 

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/generalreports/controller/GeneralReportsController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/generalreports/controller/GeneralReportsController.java
@@ -146,7 +146,7 @@ public class GeneralReportsController {
 		logger.info("getMedicinesPrescriptionExcelReport started with institution id = {}, fromDate = {}, toDate = {}", institutionId, fromDate, toDate);
 
 		try {
-			String title = "Reporte de prescripción de medicamentos (generales)";
+			String title = "Reporte de prescripción de medicamentos";
 			String[] headers = {"Nombre de prescriptor", "Licencia", "Licencia provincial", "Licencia nacional", "Fecha", "Nombre de paciente", "DNI de paciente", "Obra social", "Diagnóstico asociado", "¿Es crónico?", "Evento", "Nombre de medicamento", "Duración", "Frecuencia", "Fecha de inicio", "Fecha de fin", "Inicio de suspensión", "Fin de suspensión", "Dosificación", "Dosis diaria", "Dosis por unidad", "Observaciones", "Estado de receta"};
 
 			logger.debug("building medicines prescription excel report");

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/repository/entity/QuestionnaireResponse.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/common/repository/entity/QuestionnaireResponse.java
@@ -54,6 +54,9 @@ public class QuestionnaireResponse extends SGXAuditableEntity<Integer> {
 	@Column(name = "patient_id", nullable = false)
 	private Integer patientId;
 
+	@Column(name = "institution_id")
+	private Integer institutionId;
+
 	@Transient
 	private String createdByFullName;
 

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/controller/CreateQuestionnaireController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/controller/CreateQuestionnaireController.java
@@ -36,7 +36,7 @@ public class CreateQuestionnaireController {
 		logger.debug("QuestionnaireResponseDTO: {}", responseDTO);
 		QuestionnaireResponse createdResponse;
 		try {
-			createdResponse = questionnaireService.createQuestionnaireResponse(responseDTO, patientId);
+			createdResponse = questionnaireService.createQuestionnaireResponse(responseDTO, patientId, institutionId);
 		} catch (Exception e) {
 			logger.error("Error creating questionnaire response for patientId: {}", patientId, e);
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/domain/service/CreateQuestionnaireService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/create/domain/service/CreateQuestionnaireService.java
@@ -26,12 +26,13 @@ public class CreateQuestionnaireService {
 	private AnswerRepository answerRepository;
 
 	@Transactional
-	public QuestionnaireResponse createQuestionnaireResponse (QuestionnaireResponseDTO responseDTO, Integer patientId) {
+	public QuestionnaireResponse createQuestionnaireResponse (QuestionnaireResponseDTO responseDTO, Integer patientId, Integer institutionId) {
 		logger.info("Starting transaction to create questionnaire response for patientId: {}", patientId);
 
 		QuestionnaireResponse questionnaireResponse = new QuestionnaireResponse();
 		questionnaireResponse.setQuestionnaireId(responseDTO.getQuestionnaireId());
 		questionnaireResponse.setPatientId(patientId);
+		questionnaireResponse.setInstitutionId(institutionId);
 
 		questionnaireResponse.setStatusId(2);
 

--- a/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getpdf/domain/service/GetQuestionnairePdfService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/questionnaires/general/getpdf/domain/service/GetQuestionnairePdfService.java
@@ -11,6 +11,8 @@ import java.util.Map;
 
 import net.pladema.questionnaires.common.domain.service.QuestionnaireUtilsService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.webjars.NotFoundException;
@@ -32,6 +34,8 @@ import net.pladema.staff.repository.entity.HealthcareProfessional;
 
 @Service
 public class GetQuestionnairePdfService {
+
+	private static final Logger logger = LoggerFactory.getLogger(GetQuestionnairePdfService.class);
 
 	@Autowired
 	private final AnswerRepository answerRepository;
@@ -71,8 +75,15 @@ public class GetQuestionnairePdfService {
 		Person professionalPerson = personRepository.findById(professional.getPersonId())
 				.orElseThrow(() -> new NotFoundException("Healthcare professional person not found"));
 
-		Institution institution = institutionRepository.findById(institutionId)
-				.orElseThrow(() -> new NotFoundException("Institution not found"));
+		String institutionName = "Institución no especificada";
+
+		if (response.getInstitutionId() != null) {
+			Institution institution = institutionRepository.findById(response.getInstitutionId())
+					.orElseThrow(() -> new NotFoundException("Institution not found"));
+			institutionName = institution.getName();
+		} else {
+			logger.warn("'institution_id' is null for questionnaire response id: {}", questionnaireResponseId);
+		}
 
 		Person patientPerson = personRepository.findPersonByPatientId(response.getPatientId())
 				.orElseThrow(() -> new NotFoundException("Patient person not found"));
@@ -94,7 +105,7 @@ public class GetQuestionnairePdfService {
 		context.put("professional", professional);
 		context.put("professionalPerson", professionalPerson);
 		context.put("professionalPersonFullName", professionalPersonFullName);
-		context.put("institution", institution);
+		context.put("institutionName", institutionName);
 		context.put("patientPerson", patientPerson);
 		context.put("patientPersonFullName", patientPersonFullName);
 		context.put("patientAge", patientAge);

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/edmonton_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/edmonton_reports.html
@@ -53,7 +53,7 @@
 <body th:fragment="frail">
     <div class="container">
         <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
-        <p>Institución: <span th:text="${institution.name}"></span></p>
+        <p>Institución: <span th:text="${institutionName}"></span></p>
         <hr></hr>
         <h5>Datos del paciente</h5>
         <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/familybg_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/familybg_reports.html
@@ -48,7 +48,7 @@
 <body th:fragment="familybg">
     <div class="container">
         <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
-        <p>Institución: <span th:text="${institution.name}"></span></p>
+        <p>Institución: <span th:text="${institutionName}"></span></p>
         <hr></hr>
         <h5>Datos del paciente</h5>
         <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/frail_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/frail_reports.html
@@ -52,7 +52,7 @@
 <body th:fragment="frail">
     <div class="container">
         <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
-        <p>Institución: <span th:text="${institution.name}"></span></p>
+        <p>Institución: <span th:text="${institutionName}"></span></p>
         <hr></hr>
         <h5>Datos del paciente</h5>
         <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/physicalperformance_reports.html
@@ -52,7 +52,7 @@
 <body th:fragment="physicalperformance">
     <div class="container">
         <p style="text-align:right;">Fecha de atención: <span th:text="${formattedCreatedOn}"></span></p>
-        <p>Institución: <span th:text="${institution.name}"></span></p>
+        <p>Institución: <span th:text="${institutionName}"></span></p>
         <hr></hr>
         <h5>Datos del paciente</h5>
         <p>Apellido y nombre: <span th:text="${patientPersonFullName}"></span></p>


### PR DESCRIPTION
# Description

## Changes introduced

- Change the title of medicines prescription report inside the sheet as requested by @MaksMaks98 
- Add correct `institutionId` persisting for questionnaires **creation service**, as well as PDFs related modifications in **HTML templates**, **get pdf service** and **related entity**.
   - This also involves adding the `institution_id` column to `minsal_lr_questionnaire_response` table via the following query (@DocOc98):

        ```pgsql
        ALTER TABLE minsal_lr_questionnaire_response ADD COLUMN institution_id integer REFERENCES institution(id);
        ```

## Additional notes

- `institution_id` is nullable to conform with already created questionnaire response, which would need their `institution_id`s to be modified manually (they're null)