### PR TITLE
[Fix] Corrección de error de tipeo en "Rutas provinciales - Asistenciales"

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/rutas-larioja/rutas.component.html
+++ b/front-end/apps/projects/hospital/src/app/modules/rutas-larioja/rutas.component.html
@@ -9,7 +9,7 @@
             <mat-tab-group class="mat-primary" animationDuration="1000ms">
                 <mat-tab id="tab_programas">
                     <ng-template mat-tab-label>
-                        <span>ASITENCIALES</span>
+                        <span>ASISTENCIALES</span>
                     </ng-template>
                     <ng-template matTabContent>
                          <section>


### PR DESCRIPTION
## Versión
2.30.2

## Descripción
Se corrigió el error de tipeo observado en el módulo de "Rutas provinciales" en la pestaña de "ASISTENCIALES".