### PR TITLE
feat: add gerontological assessments report (query & code implementations)

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/odontologicalreports/controller/OdontologicalReportsController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/odontologicalreports/controller/OdontologicalReportsController.java
@@ -171,7 +171,7 @@ public class OdontologicalReportsController {
 
 		try {
 			String title = "Reporte de odontología - Procedimientos odontológicos";
-			String[] headers = {"Nombre de profesional", "DNI", "Matrícula", "Fecha de atención", "Hora", "Nombre de paciente", "DNI", "Sexo", "Fecha de nacimiento", "Edad a fecha de turno", "Obra social", "Domicilio", "Localidad", "CPO permanentes", "CEO permanentes", "Motivos", "Otros diagnósticos", "Otros procedimientos", "Alergias e intolerancias", "Medicación habitual", "Diagnósticos dentales", "Procedimientos dentales", "Evolución"};
+			String[] headers = {"Nombre de profesional", "DNI", "Matrícula", "Fecha de atención", "Hora", "Nombre de paciente", "DNI", "Sexo", "Fecha de nacimiento", "Edad a fecha de turno", "Obra social", "Domicilio", "Localidad", "CPO permanentes", "CEO temporales", "Motivos", "Otros diagnósticos", "Otros procedimientos", "Alergias e intolerancias", "Medicación habitual", "Diagnósticos dentales", "Procedimientos dentales", "Evolución"};
 
 			logger.debug("building odontological procedures excel report");
 			IWorkbook wb = excelService.buildOdontologicalProceduresExcel(title, headers, queryFactory.queryOdontologicalProcedures(institutionId, fromDate, toDate), institutionId, fromDate, toDate);

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/olderadultsreports/controller/OlderAdultReportsController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/olderadultsreports/controller/OlderAdultReportsController.java
@@ -109,4 +109,29 @@ public class OlderAdultReportsController {
 			throw new RuntimeException("error generating report", e);
 		}
 	}
+
+	@GetMapping(value = "/{institutionId}/gerontological-assessments")
+	@PreAuthorize("hasPermission(#institutionId, 'ADMINISTRADOR_INSTITUCIONAL_BACKOFFICE, PERSONAL_DE_ESTADISTICA')")
+	public ResponseEntity<byte[]> getGerontologicalAssessmentsExcelReport(
+			@PathVariable Integer institutionId,
+			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
+			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate) {
+		logger.info("getGerontologicalAssessmentsExcelReport started with institution id = {}, fromDate = {}, toDate = {}", institutionId, fromDate, toDate);
+
+		try {
+			String title = "Reporte de adulto mayor - Escalas de evaluación gerontológica";
+			String[] headers = {"Nombre de prestador", "DNI de prestador", "Especialidad", "Fecha de atención", "Hora", "Nombre de paciente", "DNI de paciente", "Sexo", "Fecha de nacimiento", "Edad al registro de evaluación", "Obra(s) social(es)", "Escala realizada", "Puntuación", "Interpretación"};
+
+			logger.debug("building gerontological assessments excel report");
+			IWorkbook wb = excelService.buildGerontologicalAssessmentsExcel(title, headers, queryFactory.queryGerontologicalAssessments(institutionId, fromDate, toDate), institutionId, fromDate, toDate);
+
+			String filename = "Adulto mayor - Escalas de evaluación gerontológica - " + excelUtilsService.getPeriodForFilenameFromDates(fromDate, toDate) + "." + wb.getExtension();
+			logger.debug("excel report generated successfully with filename = {}", filename);
+
+			return excelUtilsService.createResponseEntity(wb, filename);
+		} catch (Exception e) {
+			logger.error("error generating gerontological assessments excel report for institutionId {}", institutionId, e);
+			throw new RuntimeException("error generating report", e);
+		}
+	}
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/olderadultsreports/repository/GerontologicalAssessmentsConsultationDetail.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/olderadultsreports/repository/GerontologicalAssessmentsConsultationDetail.java
@@ -1,0 +1,39 @@
+package net.pladema.provincialreports.olderadultsreports.repository;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GerontologicalAssessmentsConsultationDetail {
+
+	private String professionalFullName;
+
+	private String professionalIdentificationNumber;
+
+	private String clinicalSpecialty;
+
+	private String patientFullName;
+
+	private String patientIdentificationNumber;
+
+	private String gender;
+
+	private String birthDate;
+
+	private String ageAtAssessmentRecord;
+
+	private String medicalCoverage;
+
+	private String attentionDate;
+
+	private String hour;
+
+	private String assessmentName;
+
+	private String assessmentScore;
+
+	private String assessmentScoreInterpretation;
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/olderadultsreports/repository/OlderAdultReportsQueryFactory.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/olderadultsreports/repository/OlderAdultReportsQueryFactory.java
@@ -29,4 +29,8 @@ public class OlderAdultReportsQueryFactory {
 	public List<PolypharmacyConsultationDetail> queryPolypharmacy(Integer institutionId, LocalDate start, LocalDate end) {
 		return repositoryUtils.executeQuery("OlderAdultsReports.PolypharmacyConsultationDetail", institutionId, start, end, null);
 	}
+
+	public List<GerontologicalAssessmentsConsultationDetail> queryGerontologicalAssessments(Integer institutionId, LocalDate start, LocalDate end) {
+		return repositoryUtils.executeQuery("OlderAdultsReports.GerontologicalAssessmentsConsultationDetail", institutionId, start, end, null);
+	}
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/olderadultsreports/service/OlderAdultReportsExcelService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/olderadultsreports/service/OlderAdultReportsExcelService.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import net.pladema.provincialreports.olderadultsreports.repository.GerontologicalAssessmentsConsultationDetail;
+
 import org.springframework.stereotype.Service;
 
 import ar.lamansys.sgx.shared.reports.util.manager.WorkbookCreator;
@@ -88,6 +90,26 @@ public class OlderAdultReportsExcelService {
 		return workbook;
 	}
 
+	public IWorkbook buildGerontologicalAssessmentsExcel(String title, String[] headers, List<GerontologicalAssessmentsConsultationDetail> result, Integer institutionId, LocalDate startDate, LocalDate endDate) {
+		IWorkbook workbook = WorkbookCreator.createExcelWorkbook();
+		excelUtilsService.createHeaderCellsStyle(workbook);
+		ISheet sheet = workbook.createSheet(title);
+		excelUtilsService.fillRow(sheet, excelUtilsService.getHeaderDataWithoutObservation(headers, title, 11, 0, excelUtilsService.periodStringFromLocalDates(startDate, endDate), institutionId, null));
+
+		AtomicInteger rowNumber = new AtomicInteger(sheet.getCantRows());
+		ICellStyle dataCellsStyle = excelUtilsService.createDataCellsStyle(workbook);
+
+		result.forEach(resultData -> {
+			IRow row = sheet.createRow(rowNumber.getAndIncrement());
+			fillGerontologicalAssessmentsRow(row, resultData, dataCellsStyle);
+		});
+
+		excelUtilsService.setMinimalHeaderDimensions(sheet);
+		excelUtilsService.setSheetDimensions(sheet);
+
+		return workbook;
+	}
+
 	public void fillOlderAdultsOutpatientRow(IRow row, OlderAdultsOutpatientConsultationDetail content, ICellStyle style) {
 		excelUtilsService.setCellValue(row, 0, style, content.getLender());
 		excelUtilsService.setCellValue(row, 1, style, content.getLenderDni());
@@ -138,5 +160,22 @@ public class OlderAdultReportsExcelService {
 		excelUtilsService.setCellValue(row, 11, style, content.getSnomed());
 		excelUtilsService.setCellValue(row, 12, style, content.getMedication());
 		excelUtilsService.setCellValue(row, 13, style, content.getMedicalInsurance());
+	}
+
+	public void fillGerontologicalAssessmentsRow(IRow row, GerontologicalAssessmentsConsultationDetail content, ICellStyle style) {
+		excelUtilsService.setCellValue(row, 0, style, content.getProfessionalFullName());
+		excelUtilsService.setCellValue(row, 1, style, content.getProfessionalIdentificationNumber());
+		excelUtilsService.setCellValue(row, 2, style, content.getClinicalSpecialty());
+		excelUtilsService.setCellValue(row, 3, style, content.getAttentionDate());
+		excelUtilsService.setCellValue(row, 4, style, content.getHour());
+		excelUtilsService.setCellValue(row, 5, style, content.getPatientFullName());
+		excelUtilsService.setCellValue(row, 6, style, content.getPatientIdentificationNumber());
+		excelUtilsService.setCellValue(row, 7, style, content.getGender());
+		excelUtilsService.setCellValue(row, 8, style, content.getBirthDate());
+		excelUtilsService.setCellValue(row, 9, style, content.getAgeAtAssessmentRecord());
+		excelUtilsService.setCellValue(row, 10, style, content.getMedicalCoverage());
+		excelUtilsService.setCellValue(row, 11, style, content.getAssessmentName());
+		excelUtilsService.setCellValue(row, 12, style, content.getAssessmentScore());
+		excelUtilsService.setCellValue(row, 13, style, content.getAssessmentScoreInterpretation());
 	}
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/reportformat/repository/ReportsRepositoryUtils.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/reportformat/repository/ReportsRepositoryUtils.java
@@ -43,4 +43,28 @@ public class ReportsRepositoryUtils {
 
 		return query.getResultList();
 	}
+
+	public <T> List<T> executeQueryTest(String queryName, Integer institutionId, LocalDate start, LocalDate end, Map<String, Object> customParams) {
+		Query query = em.createNamedQuery(queryName);
+
+		// Temporarily remove parameter setting for debugging
+		// query.setParameter("institutionId", institutionId);
+
+		// if (start != null && end != null) {
+		//     LocalDateTime startDate = start.atStartOfDay();
+		//     LocalDateTime endDate = end.atTime(LocalTime.MAX);
+		//     query.setParameter("startDate", startDate);
+		//     query.setParameter("endDate", endDate);
+		// }
+
+		// Ignore custom params for now
+		// if (customParams != null) {
+		//     for (Map.Entry<String, Object> param : customParams.entrySet()) {
+		//         query.setParameter(param.getKey(), param.getValue());
+		//     }
+		// }
+
+		return query.getResultList();
+	}
+
 }

--- a/back-end/hospital-api/src/main/resources/META-INF/orm.xml
+++ b/back-end/hospital-api/src/main/resources/META-INF/orm.xml
@@ -1646,6 +1646,91 @@
 		</query>
 	</named-native-query>
 
+	<named-native-query name="OlderAdultsReports.GerontologicalAssessmentsConsultationDetail" result-set-mapping="OlderAdultsReports.GerontologicalAssessmentsConsultationDetailResult">
+		<query>
+			SELECT
+			CONCAT_WS(' ', p.first_name, COALESCE(p.middle_names, ''), p.last_name, COALESCE(p.other_last_names, '')) AS professionalFullName,
+			CASE
+			WHEN itp.description = 'DNI' THEN p.identification_number
+			ELSE CONCAT(itp.description, ' - ', p.identification_number)
+			END AS professionalIdentificationNumber,
+
+			(
+			SELECT cs.name
+			FROM outpatient_consultation oc
+			LEFT JOIN clinical_specialty cs ON oc.clinical_specialty_id = cs.id
+			WHERE oc.patient_id = pt.id
+			LIMIT 1
+			) AS clinicalSpecialty,
+
+			CONCAT_WS(' ', pp.first_name, COALESCE(pp.middle_names, ''), pp.last_name, COALESCE(pp.other_last_names, '')) AS patientFullName,
+			CASE
+			WHEN itp.description = 'DNI' THEN pp.identification_number
+			ELSE CONCAT(itp.description, ' - ', pp.identification_number)
+			END AS patientIdentificationNumber,
+			g.description AS gender,
+			TO_CHAR(pp.birth_date, 'DD/MM/YYYY') AS birthDate,
+			CONCAT(EXTRACT(YEAR FROM AGE(qr.created_on, pp.birth_date)), ' años') AS ageAtAssessmentRecord,
+
+			(
+			SELECT
+			string_agg(
+			CASE
+			WHEN hi.rnos IS NOT NULL THEN concat(mc.name, ' (RNOS: ', hi.rnos, ')')
+			ELSE mc.name
+			END, ', '
+			)
+			FROM
+			patient_medical_coverage pmc
+			LEFT JOIN medical_coverage mc ON pmc.medical_coverage_id = mc.id
+			LEFT JOIN health_insurance hi ON hi.id = mc.id
+			WHERE
+			pmc.patient_id = pt.id
+			) AS medicalCoverage,
+
+			TO_CHAR(
+			CASE
+			WHEN EXTRACT(HOUR FROM qr.created_on) &lt; 3 THEN
+			CAST(qr.created_on - INTERVAL '1 day' AS DATE)
+			ELSE
+			CAST(qr.created_on AS DATE)
+			END, 'DD/MM/YYYY'
+			) AS attentionDate,
+
+
+			TO_CHAR(qr.created_on AT TIME ZONE 'UTC-3', 'HH24:MI') AS hour,
+
+			q.description AS assessmentName,
+
+			CASE
+			WHEN q.id IN (1, 3, 4) THEN a.value
+			ELSE NULL
+			END AS assessmentScore,
+
+			o.value AS assessmentScoreInterpretation
+
+			FROM
+			minsal_lr_questionnaire_response qr
+			JOIN users u ON qr.created_by = u.id
+			JOIN user_person up ON u.id = up.user_id
+			JOIN person p ON up.person_id = p.id
+			JOIN patient pt ON qr.patient_id = pt.id
+			JOIN person pp ON pt.person_id = pp.id
+			JOIN gender g ON pp.gender_id = g.id
+			JOIN minsal_lr_questionnaire q ON qr.questionnaire_id = q.id
+			LEFT JOIN minsal_lr_answer a ON a.questionnaire_response_id = qr.id
+			AND ((q.id = 1 AND a.item_id = 22) OR (q.id = 3 AND a.item_id = 70) OR (q.id = 4 AND a.item_id = 88))
+			LEFT JOIN minsal_lr_option o ON a.option_id = o.id
+			LEFT JOIN identification_type it ON p.identification_type_id = it.id
+			LEFT JOIN identification_type itp ON pp.identification_type_id = itp.id
+			WHERE
+				q.id IN (1, 3, 4)
+				AND qr.institution_id = :institutionId
+				AND qr.created_on >= :startDate AND qr.created_on &lt; :endDate
+			ORDER BY qr.created_on;
+		</query>
+	</named-native-query>
+
 	<!-- ========================================== -->
 	<!-- =========== Odontology Reports =========== -->
 	<!-- ========================================== -->
@@ -3152,6 +3237,24 @@
 			<column name="professionalSpeciality" class="java.lang.String"/>
 			<column name="prescriptionDate" class="java.lang.String"/>
 			<column name="prescriptionUpdateDate" class="java.lang.String"/>
+		</constructor-result>
+	</sql-result-set-mapping>
+	<sql-result-set-mapping name="OlderAdultsReports.GerontologicalAssessmentsConsultationDetailResult">
+		<constructor-result target-class="net.pladema.provincialreports.olderadultsreports.repository.GerontologicalAssessmentsConsultationDetail">
+			<column name="professionalFullName" class="java.lang.String"/>
+			<column name="professionalIdentificationNumber" class="java.lang.String"/>
+			<column name="clinicalSpecialty" class="java.lang.String"/>
+			<column name="patientFullName" class="java.lang.String"/>
+			<column name="patientIdentificationNumber" class="java.lang.String"/>
+			<column name="gender" class="java.lang.String"/>
+			<column name="birthDate" class="java.lang.String"/>
+			<column name="ageAtAssessmentRecord" class="java.lang.String"/>
+			<column name="medicalCoverage" class="java.lang.String"/>
+			<column name="attentionDate" class="java.lang.String"/>
+			<column name="hour" class="java.lang.String"/>
+			<column name="assessmentName" class="java.lang.String"/>
+			<column name="assessmentScore" class="java.lang.String"/>
+			<column name="assessmentScoreInterpretation" class="java.lang.String"/>
 		</constructor-result>
 	</sql-result-set-mapping>
 


### PR DESCRIPTION
# Gerontological assessment scales report

### Changes

- This PR introduces the gerontological assessments report to the _older adults_ reports group. It's located in the following route:
   - `olderadultsreports/{institutionId}/gerontological-assessments`
   - `institutionId` as **route** parameter, and `fromDate` and `toDate` as request parameters (**YYYY-MM-DD** format)
   - Allowed roles: `ADMINISTRADOR_INSTITUCIONAL_BACKOFFICE`, `PERSONAL_DE_ESTADISTICA`
- The PR also fixes a wrong value used as a column header in the '**odontological procedures**' report

### Testing

- Manual controller endpoint testing performed using Swagger

### Related issues and resources

- Fixes #217 