### PR TITLE
Fix: nursing outpatient and medicines prescription

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/generalreports/controller/GeneralReportsController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/generalreports/controller/GeneralReportsController.java
@@ -147,7 +147,7 @@ public class GeneralReportsController {
 
 		try {
 			String title = "Reporte de prescripción de medicamentos";
-			String[] headers = {"Nombre de prescriptor", "Licencia", "Licencia provincial", "Licencia nacional", "Fecha", "Nombre de paciente", "DNI de paciente", "Obra social", "Diagnóstico asociado", "¿Es crónico?", "Evento", "Nombre de medicamento", "Duración", "Frecuencia", "Fecha de inicio", "Fecha de fin", "Inicio de suspensión", "Fin de suspensión", "Dosificación", "Dosis diaria", "Dosis por unidad", "Observaciones", "Estado de receta"};
+			String[] headers = {"Nombre de prescriptor", "Licencia", "Licencia provincial", "Licencia nacional", "Fecha", "Nombre de paciente", "DNI de paciente", "Obra social", "Diagnóstico asociado", "¿Es crónico?", "Evento", "Prescripción", "Nombre de medicamento", "Duración", "Frecuencia", "Fecha de inicio", "Fecha de fin", "Inicio de suspensión", "Fin de suspensión", "Dosificación", "Dosis diaria", "Dosis por unidad", "Observaciones", "Estado de receta"};
 
 			logger.debug("building medicines prescription excel report");
 			IWorkbook wb = excelService.buildMedicinesPrescriptionExcel(title, headers, queryFactory.queryMedicinesPrescription(institutionId, fromDate, toDate), institutionId, fromDate, toDate);

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/generalreports/repository/MedicinesPrescriptionConsultationDetail.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/generalreports/repository/MedicinesPrescriptionConsultationDetail.java
@@ -26,6 +26,7 @@ public class MedicinesPrescriptionConsultationDetail {
 	private String relatedDiagnosis;
 	private String isChronic;
 	private String event;
+	private String prescription;
 	private String duration;
 	private String frequency;
 	private String startDate;

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/generalreports/service/GeneralReportsExcelService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/generalreports/service/GeneralReportsExcelService.java
@@ -97,7 +97,7 @@ public class GeneralReportsExcelService {
 		IWorkbook workbook = WorkbookCreator.createExcelWorkbook();
 		excelUtilsService.createHeaderCellsStyle(workbook);
 		ISheet sheet = workbook.createSheet(title);
-		excelUtilsService.fillRow(sheet, excelUtilsService.getHeaderDataWithoutObservation(headers, title, 20, 0, excelUtilsService.periodStringFromLocalDates(startDate, endDate), institutionId, null));
+		excelUtilsService.fillRow(sheet, excelUtilsService.getHeaderDataWithoutObservation(headers, title, 21, 0, excelUtilsService.periodStringFromLocalDates(startDate, endDate), institutionId, null));
 
 		AtomicInteger rowNumber = new AtomicInteger(sheet.getCantRows());
 		ICellStyle dataCellsStyle = excelUtilsService.createDataCellsStyle(workbook);
@@ -186,17 +186,18 @@ public class GeneralReportsExcelService {
 		excelUtilsService.setCellValue(row, 8, style, content.getRelatedDiagnosis());
 		excelUtilsService.setCellValue(row, 9, style, content.getIsChronic());
 		excelUtilsService.setCellValue(row, 10, style, content.getEvent());
-		excelUtilsService.setCellValue(row, 11, style, content.getMedicine());
-		excelUtilsService.setCellValue(row, 12, style, content.getDuration());
-		excelUtilsService.setCellValue(row, 13, style, content.getFrequency());
-		excelUtilsService.setCellValue(row, 14, style, dateTools.newReformatDate(content.getStartDate(), "dd-MM-yyyy HH:mm"));
-		excelUtilsService.setCellValue(row, 15, style, dateTools.newReformatDate(content.getEndDate(), "dd-MM-yyyy HH:mm"));
-		excelUtilsService.setCellValue(row, 16, style, dateTools.newReformatDate(content.getSuspensionStartDate(), "dd-MM-yyyy"));
-		excelUtilsService.setCellValue(row, 17, style, dateTools.newReformatDate(content.getSuspensionEndDate(), "dd-MM-yyyy"));
-		excelUtilsService.setCellValue(row, 18, style, content.getDosage());
-		excelUtilsService.setCellValue(row, 19, style, content.getDosePerDay());
-		excelUtilsService.setCellValue(row, 20, style, content.getDosePerUnit());
-		excelUtilsService.setCellValue(row, 21, style, content.getObservations());
-		excelUtilsService.setCellValue(row, 22, style, content.getPrescriptionStatus());
+		excelUtilsService.setCellValue(row, 11, style, content.getPrescription());
+		excelUtilsService.setCellValue(row, 12, style, content.getMedicine());
+		excelUtilsService.setCellValue(row, 13, style, content.getDuration());
+		excelUtilsService.setCellValue(row, 14, style, content.getFrequency());
+		excelUtilsService.setCellValue(row, 15, style, dateTools.newReformatDate(content.getStartDate(), "dd-MM-yyyy HH:mm"));
+		excelUtilsService.setCellValue(row, 16, style, dateTools.newReformatDate(content.getEndDate(), "dd-MM-yyyy HH:mm"));
+		excelUtilsService.setCellValue(row, 17, style, dateTools.newReformatDate(content.getSuspensionStartDate(), "dd-MM-yyyy"));
+		excelUtilsService.setCellValue(row, 18, style, dateTools.newReformatDate(content.getSuspensionEndDate(), "dd-MM-yyyy"));
+		excelUtilsService.setCellValue(row, 19, style, content.getDosage());
+		excelUtilsService.setCellValue(row, 20, style, content.getDosePerDay());
+		excelUtilsService.setCellValue(row, 21, style, content.getDosePerUnit());
+		excelUtilsService.setCellValue(row, 22, style, content.getObservations());
+		excelUtilsService.setCellValue(row, 23, style, content.getPrescriptionStatus());
 	}
 }

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/nursingreports/controller/NursingReportsController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/nursingreports/controller/NursingReportsController.java
@@ -73,7 +73,7 @@ public class NursingReportsController {
 
 		try {
 			String title = "Reporte de enfermería ambulatoria";
-			String[] headers = {"Prestador", "DNI de prestador", "Fecha de atención", "Hora", "N° de consulta", "DNI de paciente", "Nombre de paciente", "Sexo", "Fecha de nacimiento", "Edad a fecha de turno", "Edad a hoy", "Etnia", "Obra(s) social(es)", "Domicilio", "Localidad", "Frecuencia cardíaca (lpm)", "Frecuencia respiratoria (rpm)", "Temperatura (°C)", "Saturación periférica de hemoglobina con oxígeno (SpO2)", "Presión sistólica (mmHg)", "Presión diastólica (mmHg)", "Presión arterial media (mmHg)", "Altura (cm)", "Peso (kg)", "Índice de masa corporal", "Hemoglobina glicosilada (%)", "Riesgo cardiovascular (%)", "Glucemia (mg/dl)", "Procedimientos", "Evolución"};
+			String[] headers = {"Nombre de prestador", "DNI de prestador", "Fecha de atención", "Hora", "N° de consulta", "DNI de paciente", "Nombre de paciente", "Sexo", "Fecha de nacimiento", "Edad a fecha del turno", "Edad actual", "Etnia", "Obra(s) social(es)", "Domicilio", "Localidad", "Frecuencia cardíaca (lpm)", "Frecuencia respiratoria (rpm)", "Temperatura (°C)", "Saturación de hemoglobina con oxígeno (SpO₂)", "Presión sistólica (mmHg)", "Presión diastólica (mmHg)", "Presión arterial media (mmHg)", "Glucemia (mg/dL)", "Hemoglobina glicosilada (%)", "Riesgo cardiovascular (%)", "Altura (cm)", "Peso (kg)", "IMC (kg/m²)", "Procedimientos", "Evolución"};
 			logger.debug("building nursing outpatient excel report");
 			IWorkbook wb = excelService.buildNursingOutpatientExcel(title, headers, queryFactory.queryNursingOutpatient(institutionId, fromDate, toDate), institutionId, fromDate, toDate);
 

--- a/back-end/hospital-api/src/main/java/net/pladema/provincialreports/nursingreports/service/NursingReportsExcelService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/provincialreports/nursingreports/service/NursingReportsExcelService.java
@@ -56,7 +56,7 @@ public class NursingReportsExcelService {
 		IWorkbook workbook = WorkbookCreator.createExcelWorkbook();
 		excelUtilsService.createHeaderCellsStyle(workbook);
 		ISheet sheet = workbook.createSheet(title);
-		excelUtilsService.fillRow(sheet, excelUtilsService.getHeaderDataWithoutObservation(headers, title, 29, 0, excelUtilsService.periodStringFromLocalDates(startDate, endDate), institutionId, null));
+		excelUtilsService.fillRow(sheet, excelUtilsService.getHeaderDataWithoutObservation(headers, title, 27, 0, excelUtilsService.periodStringFromLocalDates(startDate, endDate), institutionId, null));
 
 		AtomicInteger rowNumber = new AtomicInteger(sheet.getCantRows());
 		ICellStyle dataCellsStyle = excelUtilsService.createDataCellsStyle(workbook);
@@ -165,7 +165,6 @@ public class NursingReportsExcelService {
 	}
 
 	public void fillNursingOutpatientRow(IRow row, NursingOutpatientConsultationDetail content, ICellStyle style) {
-		// no glycosilated hemoglobin, blood sugar, cardiovascular risk
 		excelUtilsService.setCellValue(row, 0, style, content.getPatientProvider());
 		excelUtilsService.setCellValue(row, 1, style, content.getProviderDni());
 		excelUtilsService.setCellValue(row, 2, style, dateTools.newReformatDate(content.getAttentionDate(), "dd-MM-yyyy"));
@@ -188,14 +187,14 @@ public class NursingReportsExcelService {
 		excelUtilsService.setCellValue(row, 19, style, content.getSystolicPressure());
 		excelUtilsService.setCellValue(row, 20, style, content.getDiastolicPressure());
 		excelUtilsService.setCellValue(row, 21, style, content.getMeanArterialPressure());
-		excelUtilsService.setCellValue(row, 22, style, content.getHeight());
-		excelUtilsService.setCellValue(row, 23, style, content.getWeight());
-		excelUtilsService.setCellValue(row, 24, style, content.getBmi());
-		excelUtilsService.setCellValue(row, 24, style, content.getGlycosylatedHemoglobin());
-		excelUtilsService.setCellValue(row, 25, style, content.getCardiovascularRisk());
-		excelUtilsService.setCellValue(row, 26, style, content.getBloodSugar());
-		excelUtilsService.setCellValue(row, 27, style, content.getProcedures());
-		excelUtilsService.setCellValue(row, 28, style, content.getEvolution());
+		excelUtilsService.setCellValue(row, 22, style, content.getBloodSugar());
+		excelUtilsService.setCellValue(row, 23, style, content.getGlycosylatedHemoglobin());
+		excelUtilsService.setCellValue(row, 24, style, content.getCardiovascularRisk());
+		excelUtilsService.setCellValue(row, 25, style, content.getHeight());
+		excelUtilsService.setCellValue(row, 26, style, content.getWeight());
+		excelUtilsService.setCellValue(row, 27, style, content.getBmi());
+		excelUtilsService.setCellValue(row, 28, style, content.getProcedures());
+		excelUtilsService.setCellValue(row, 29, style, content.getEvolution());
 	}
 
 	public void fillNursingHospitalizationRow(IRow row, NursingHospitalizationConsultationDetail content, ICellStyle style) {

--- a/back-end/hospital-api/src/main/resources/META-INF/orm.xml
+++ b/back-end/hospital-api/src/main/resources/META-INF/orm.xml
@@ -1421,7 +1421,12 @@
 			(select string_agg(concat(psp.description_profession_ref, ': ', lic.license_number), ' | ') FROM professional_professions ppr inner join professional_specialty psp ON psp.id=ppr.professional_specialty_id inner join professional_license_numbers lic on ppr.id=lic.professional_profession_id WHERE ppr.healthcare_professional_id=hp.id and lic.type_license_number=2) as prescriberProvincialLicense,
 			concat(pe.last_name, ' ', pe.other_last_names, ' ', pe.first_name, ' ', pe.middle_names) AS patient, pe.identification_number AS patientDNI, concat(mc.name, '(RNOS: ', hi.rnos, ')') AS medicalCoverage,
 			concat(s.pt, '(SNOMED: ', s.sctid,')') AS medicine, concat(sn_hc.pt, '(SNOMED: ', sn_hc.sctid,')') AS relatedDiagnosis,
-			case when dsg.chronic is true then 'Sí' else 'No' end as isChronic, dsg.event as event, concat(dsg.duration, ' ', dsg.duration_unit) as duration, concat(dsg.frequency, ' ', dsg.period_unit) as frequency,
+			case when dsg.chronic is true then 'Sí' else 'No' end as isChronic, dsg.event as event,
+			CASE
+			WHEN mr.has_recipe IS FALSE THEN 'Sin receta'
+			ELSE concat('Receta #', mr.id)
+			END AS prescription,
+			concat(dsg.duration, ' ', dsg.duration_unit) as duration, concat(dsg.frequency, ' ', dsg.period_unit) as frequency,
 			dsg.start_date as startDate, dsg.end_date as endDate, dsg.suspended_start_date as suspensionStartDate, dsg.suspended_end_date as suspensionEndDate,
 			concat(qt.value, ' ', qt.unit) as dosage, dsg.doses_by_day as dosePerDay, dsg.doses_by_unit as dosePerUnit, ev.description as observations
 			FROM medication_request mr
@@ -3057,6 +3062,7 @@
 			<column name="relatedDiagnosis" class="java.lang.String"/>
 			<column name="isChronic" class="java.lang.String"/>
 			<column name="event" class="java.lang.String"/>
+			<column name="prescription" class="java.lang.String"/>
 			<column name="duration" class="java.lang.String"/>
 			<column name="frequency" class="java.lang.String"/>
 			<column name="startDate" class="java.lang.String"/>

--- a/back-end/hospital-api/src/main/resources/META-INF/orm.xml
+++ b/back-end/hospital-api/src/main/resources/META-INF/orm.xml
@@ -1998,7 +1998,7 @@
 			(select ovs.value FROM document_vital_sign dvs INNER JOIN observation_vital_sign ovs on dvs.observation_vital_sign_id=ovs.id inner join snomed s_vs on ovs.snomed_id=s_vs.id where dvs.document_id=d.id and s_vs.id=677) as cardiovascularRisk,
 			(select ovs.value FROM document_vital_sign dvs INNER JOIN observation_vital_sign ovs on dvs.observation_vital_sign_id=ovs.id inner join snomed s_vs on ovs.snomed_id=s_vs.id where dvs.document_id=d.id and s_vs.id=675) as bloodSugar,
 			(SELECT string_agg(concat(s_proc.pt, '(', ps.description, ' | SNOMED: ', s_proc.sctid, ' | CIE10: ', proc.cie10_codes, ')'), ', ') FROM document_procedure dp INNER JOIN procedures proc ON dp.procedure_id=proc.id INNER JOIN procedures_status ps ON proc.status_id=ps.id INNER JOIN snomed s_proc ON proc.snomed_id=s_proc.id WHERE dp.document_id=d.id) AS procedures,
-			(SELECT string_agg(ev.description, ', ') FROM note ev WHERE d.other_note_id=ev.id) AS evolution
+			(SELECT string_agg(ev.description, ', ') FROM note ev WHERE d.source_id=ev.id) AS evolution
 			FROM nursing_consultation oc
 			LEFT JOIN institution ins ON oc.institution_id=ins.id
 			LEFT JOIN clinical_specialty cs ON oc.clinical_specialty_id=cs.id


### PR DESCRIPTION
# Nursing outpatient, medicines prescription reports

### Changes

This PR introduces the following changes:

- Add `prescription` column to **medicines prescription report** (**general** reports group)
- Fix `evolution` field being empty in **nursing outpatient report** (**nursing** reports group)
- Reorder some columns in **nursing outpatient report** to conform with the specified user story

### Testing

- Manual controller endpoint testing performed using Swagger

### Related issues and resources

- Fixes #215 