### PR TITLE
[Frontend] Incorporación del reporte 'Escalas de Evalución Gerontológica'

### DIFF
--- a/front-end/apps/projects/hospital/src/app/modules/api-rest/services/olderadult-reports.service.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/api-rest/services/olderadult-reports.service.ts
@@ -38,5 +38,9 @@ export class OlderadultReportsService {
     const url = `${environment.apiBase}/olderadultsreports/${this.contextService.institutionId}/polypharmacy`;
     return this.getOlderadultReport(params, fileName, url);
   }
-
+  
+  getGerontologicalAssessmentsExcelReport(params: any, fileName: string): Observable<any> {
+    const url = `${environment.apiBase}/olderadultsreports/${this.contextService.institutionId}/gerontological-assessments`;
+    return this.getOlderadultReport(params, fileName, url);
+  }
 }

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-adultomayor/constants/olderadult-report-types.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-adultomayor/constants/olderadult-report-types.ts
@@ -11,5 +11,9 @@ export const OLDERADULT_REPORT_TYPES = [
     {
         description: 'Polifarmacia',
         id: 3,
+    },
+    {
+        description: 'Escalas de evaluación gerontológica',
+        id: 4,
     }
 ]

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-adultomayor/constants/olderadult-report-types.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-adultomayor/constants/olderadult-report-types.ts
@@ -13,7 +13,7 @@ export const OLDERADULT_REPORT_TYPES = [
         id: 3,
     },
     {
-        description: 'Escalas de evaluación gerontológica',
+        description: 'Escalas de Evaluación Gerontológica',
         id: 4,
     }
 ]

--- a/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-adultomayor/reportes-adultomayor.component.ts
+++ b/front-end/apps/projects/hospital/src/app/modules/reportes-larioja/reportes-adultomayor/reportes-adultomayor.component.ts
@@ -100,7 +100,10 @@ export class ReportesAdultomayorComponent implements OnInit {
         case 3:
           this.olderadultReportsService.getPolypharmacyReport(params, `${this.REPORT_TYPES[2].description}.xls`).subscribe();
           break;
-        default:
+        case 4:
+          this.olderadultReportsService.getGerontologicalAssessmentsExcelReport(params, `${this.REPORT_TYPES[3].description}.xls`).subscribe();
+          break;
+          default:
       }
     }
   }


### PR DESCRIPTION
## Version
2.30.2
## Descripción
Este pull request implementa la creación del reporte titulado “Evaluaciones gerontológicas” en la pestaña de “Adulto Mayor” del módulo de “Reportes provinciales de HSI”.

## Cambios Realizados
- **Integración de Endpoint:** Se ha añadido el endpoint proporcionado por el backend para obtener los datos necesarios para el reporte. Ruta: `olderadultsreports/{institutionId}/gerontological-assessments`
- **Tipo de Reporte:** Se ha especificado el tipo de reporte correspondiente a “Evaluaciones gerontológicas”. 
- **Método de Descarga:** Se ha implementado el método para la descarga del archivo en formato Excel.

## Detalles técnicos
**Archivos afectado:** [olderadult-report-types.ts], [reportes-adultomayor.component.ts], [olderadult-reports.service.ts]

Closes: #222

## Funciones Añadidas:
**getOlderAdultsHospitalizationReport():** Método para llamar al endpoint y obtener los datos.
**generateOlderadultReport():** Método para permitir la descarga del archivo Excel generado con los resultados.
## Pruebas
Se han realizado pruebas unitarias sobre los métodos implementados asegurando el correcto funcionamiento de la generación y descarga del reporte.

## Resultado esperado
![image](https://github.com/user-attachments/assets/ede54b13-ed6f-4edb-ac0f-9d8808f427f5)

![image](https://github.com/user-attachments/assets/6d126b8d-8a7f-4029-acb5-2866e4b1d42e)
