### PR TITLE
Feat: annex in emergency care ("guardia")

### DIFF
--- a/back-end/hospital-api/src/main/java/net/pladema/emergencycareannex/controller/AnnexInECEController.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/emergencycareannex/controller/AnnexInECEController.java
@@ -1,0 +1,74 @@
+package net.pladema.emergencycareannex.controller;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import ar.lamansys.sgx.shared.files.pdf.PDFDocumentException;
+import ar.lamansys.sgx.shared.filestorage.application.FileContentBo;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import net.pladema.emergencycareannex.domain.service.AnnexInECEService;
+
+@RestController
+@RequestMapping
+@Tag(name = "Annex in emergency care episode", description = "Anexo en módulo de guardia")
+public class AnnexInECEController {
+	private final Logger logger = LoggerFactory.getLogger(AnnexInECEController.class);
+
+	private final AnnexInECEService service;
+
+	@Autowired
+	public AnnexInECEController(AnnexInECEService service) {
+		this.service = service;
+	}
+
+	@PreAuthorize("hasPermission(#institutionId, 'ESPECIALISTA_MEDICO, PROFESIONAL_DE_SALUD, ENFERMERO_ADULTO_MAYOR, ENFERMERO, ESPECIALISTA_EN_ODONTOLOGIA')")
+	@GetMapping("/institution/{institutionId}/emergency-care/episodes/{episodeId}/annex-pdf")
+	public ResponseEntity<InputStreamResource> downloadEpisodePdf(@PathVariable Integer institutionId, @PathVariable Integer episodeId) throws PDFDocumentException {
+		logger.debug("input parameters -> institutionId: {}, episodeId: {}", institutionId, episodeId);
+
+		FileContentBo fileContentBo;
+		try {
+			fileContentBo = service.generateEpisodePdf(episodeId);
+			logger.info("Successfully generated PDF for episodeId: {}", episodeId);
+		} catch (Exception e) {
+			logger.error("Error generating PDF for episodeId: {}", episodeId, e);
+			throw e;
+		}
+
+		String outputFileName = "Anexo II - Guardia - ID " + episodeId + ".pdf";
+
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		try {
+			fileContentBo.getStream().transferTo(outputStream);
+			logger.info("Successfully transferred PDF content to output stream for episodeId: {}", episodeId);
+		} catch (IOException e) {
+			logger.error("Error transferring stream to output stream", e);
+			throw new RuntimeException("Error while transferring the PDF content", e);
+		}
+
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+		InputStreamResource resource = new InputStreamResource(inputStream);
+
+		logger.info("Returning PDF response for episodeId: {}", episodeId);
+
+		return ResponseEntity.ok()
+				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + outputFileName)
+				.contentType(MediaType.APPLICATION_PDF)
+				.contentLength(outputStream.size())
+				.body(resource);
+	}
+}

--- a/back-end/hospital-api/src/main/java/net/pladema/emergencycareannex/domain/service/AnnexInECEService.java
+++ b/back-end/hospital-api/src/main/java/net/pladema/emergencycareannex/domain/service/AnnexInECEService.java
@@ -1,0 +1,162 @@
+package net.pladema.emergencycareannex.domain.service;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import net.pladema.emergencycare.repository.EmergencyCareTypeRepository;
+import net.pladema.emergencycare.repository.entity.EmergencyCareType;
+import net.pladema.establishment.repository.InstitutionRepository;
+import net.pladema.establishment.repository.entity.Institution;
+import net.pladema.person.repository.HealthInsuranceRepository;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import ar.lamansys.sgx.shared.files.pdf.PDFDocumentException;
+import ar.lamansys.sgx.shared.files.pdf.PdfService;
+import ar.lamansys.sgx.shared.filestorage.application.FileContentBo;
+import net.pladema.emergencycare.repository.EmergencyCareEpisodeRepository;
+import net.pladema.emergencycare.repository.entity.EmergencyCareEpisode;
+import net.pladema.patient.repository.MedicalCoverageRepository;
+import net.pladema.patient.repository.entity.MedicalCoverage;
+import net.pladema.person.repository.GenderRepository;
+import net.pladema.person.repository.IdentificationTypeRepository;
+import net.pladema.person.repository.PersonRepository;
+import net.pladema.person.repository.entity.Gender;
+import net.pladema.person.repository.entity.HealthInsurance;
+import net.pladema.person.repository.entity.IdentificationType;
+import net.pladema.person.repository.entity.Person;
+
+@Service
+public class AnnexInECEService {
+
+	private static final Logger logger = LoggerFactory.getLogger(AnnexInECEService.class);
+
+	private final EmergencyCareEpisodeRepository emergencyCareEpisodeRepository;
+	private final PersonRepository personRepository;
+	private final IdentificationTypeRepository identificationTypeRepository;
+	private final GenderRepository genderRepository;
+	private final MedicalCoverageRepository medicalCoverageRepository;
+	private final HealthInsuranceRepository healthInsuranceRepository;
+	private final EmergencyCareTypeRepository emergencyCareTypeRepository;
+	private final InstitutionRepository institutionRepository;
+	private final PdfService pdfService;
+
+	public AnnexInECEService(EmergencyCareEpisodeRepository emergencyCareEpisodeRepository, PersonRepository personRepository, PdfService pdfService, IdentificationTypeRepository identificationTypeRepository, GenderRepository genderRepository, MedicalCoverageRepository medicalCoverageRepository, HealthInsuranceRepository healthInsuranceRepository, EmergencyCareTypeRepository emergencyCareTypeRepository, InstitutionRepository institutionRepository) {
+		this.emergencyCareEpisodeRepository = emergencyCareEpisodeRepository;
+		this.personRepository = personRepository;
+		this.pdfService = pdfService;
+		this.identificationTypeRepository = identificationTypeRepository;
+		this.genderRepository = genderRepository;
+		this.medicalCoverageRepository = medicalCoverageRepository;
+		this.healthInsuranceRepository = healthInsuranceRepository;
+		this.emergencyCareTypeRepository = emergencyCareTypeRepository;
+		this.institutionRepository = institutionRepository;
+	}
+
+	public FileContentBo generateEpisodePdf(Integer episodeId) throws PDFDocumentException {
+		logger.info("Executing query with episodeId {}", episodeId);
+
+		Map<String, Object> contextMap;
+		try {
+			contextMap = fetchEpisodeContext(episodeId);
+			logger.info("Fetched context map: {}", contextMap);
+		} catch (Exception e) {
+			logger.error("Error fetching episode context for episodeId {}", episodeId, e);
+			throw e;
+		}
+
+		if (contextMap == null || contextMap.isEmpty()) {
+			logger.warn("No data found for episode ID: {}", episodeId);
+			throw new IllegalArgumentException("No data found for episode ID: " + episodeId);
+		}
+
+		String templateName = "annex_in_ece";
+
+		try {
+			return pdfService.generate(templateName, contextMap);
+		} catch (Exception e) {
+			logger.error("Error generating PDF for episodeId {} with context map {}", episodeId, contextMap, e);
+			throw e;
+		}
+	}
+
+	public Map<String, Object> fetchEpisodeContext(Integer episodeId) {
+		Map<String, Object> context = new HashMap<>();
+
+		Optional<EmergencyCareEpisode> episodeOptional = emergencyCareEpisodeRepository.findById(episodeId);
+		if (episodeOptional.isPresent()) {
+			EmergencyCareEpisode episode = episodeOptional.get();
+
+			Optional<Person> personOptional = personRepository.findPersonByPatientId(episode.getPatientId());
+			personOptional.ifPresent(person -> {
+				String patientName = Stream.of(
+						person.getLastName(),
+						person.getOtherLastNames(),
+						person.getFirstName(),
+						person.getMiddleNames()
+				).filter(Objects::nonNull)
+						.collect(Collectors.joining(" "))
+						.trim();
+				context.put("patientName", patientName.isEmpty() ? null : patientName);
+
+				context.put("identificationNumber", person.getIdentificationNumber());
+
+				Optional<IdentificationType> identificationTypeOptional = Optional.ofNullable(person.getIdentificationTypeId())
+						.flatMap(identificationTypeRepository::findById);
+				context.put("identificationType", identificationTypeOptional
+						.map(IdentificationType::getDescription)
+						.orElse(null));
+
+				Optional<Gender> genderOptional = Optional.ofNullable(person.getGenderId())
+						.flatMap(genderRepository::findById);
+				context.put("gender", genderOptional
+						.map(Gender::getDescription)
+						.orElse(null));
+
+				context.put("patientAge", Optional.ofNullable(person.getBirthDate())
+						.flatMap(birthDate -> Optional.ofNullable(episode.getCreatedOn())
+								.map(createdOn -> ChronoUnit.YEARS.between(birthDate, createdOn.toLocalDate())))
+						.orElse(null));
+			});
+
+			Optional<MedicalCoverage> medicalCoverageOptional = Optional.ofNullable(episode.getPatientMedicalCoverageId())
+					.flatMap(medicalCoverageRepository::findById);
+			context.put("medicalCoverageName", medicalCoverageOptional
+					.map(MedicalCoverage::getName)
+					.orElse(null));
+
+			Optional<HealthInsurance> healthInsuranceOptional = medicalCoverageOptional
+					.flatMap(medicalCoverage -> healthInsuranceRepository.findById(medicalCoverage.getId()));
+			context.put("medicalCoverageRnos", healthInsuranceOptional
+					.map(HealthInsurance::getRnos)
+					.orElse(null));
+
+			context.put("attentionDate", episode.getCreatedOn() != null ?
+					episode.getCreatedOn().atZone(ZoneId.of("UTC-3")).format(DateTimeFormatter.ofPattern("dd/MM/yyyy")) : null);
+			context.put("diagnosis", episode.getReason());
+
+			Optional<EmergencyCareType> emergencyCareTypeOptional = Optional.ofNullable(episode.getEmergencyCareTypeId())
+					.flatMap(emergencyCareTypeRepository::findById);
+			context.put("clinicalSpecialty", emergencyCareTypeOptional
+					.map(EmergencyCareType::getDescription)
+					.orElse(null));
+
+			Optional<Institution> institutionOptional = institutionRepository.findById(episode.getInstitutionId());
+			institutionOptional.ifPresent(institution -> {
+				context.put("institutionName", institution.getName());
+				context.put("institutionSisaCode", institution.getSisaCode());
+			});
+		}
+
+		return context;
+	}
+}

--- a/back-end/hospital-api/src/main/resources/templates/flavors/minsal/annex_in_ece.html
+++ b/back-end/hospital-api/src/main/resources/templates/flavors/minsal/annex_in_ece.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="es">
+<head>
+    <meta charset="UTF-8"></meta>
+    <meta name="viewport" content="width=device-width, initial-scale=1"></meta>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></meta>
+
+    <title>Anexo II en guardia (comprobante de atención médica)</title>
+
+    <style>
+        @page {
+            size: A4;
+            margin: 20mm;
+            @top-center { content: ""; }
+            @bottom-center { content: ""; }
+        }
+
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 12px;
+            margin: 0;
+            padding: 0;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 210mm;
+            margin: 0 auto;
+            box-sizing: border-box;
+        }
+
+        .title {
+            background-color: #c5cfc6;
+            border: 1px solid black;
+        }
+
+        .styled-hr {
+            width: 100%;
+            border: thin solid #bfbfbf;
+            margin: 5px 0;
+        }
+
+        .left-aligned-text {
+            text-align: left;
+        }
+
+        table, th, td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            text-align: center;
+        }
+
+        table {
+            width: 100%;
+        }
+
+        table + table {
+            margin-top: -1px;
+        }
+
+        th, td {
+            padding: 10px;
+            box-sizing: border-box;
+        }
+
+        .full-width {
+            width: 100%;
+        }
+
+        .no-top-border {
+            border-top: none;
+        }
+
+        .no-bottom-border {
+            border-bottom: none;
+        }
+    </style>
+</head>
+<body th:fragment="annex_in_ece">
+    <div class="container">
+        <table class="full-width">
+            <tr>
+                <td style="width:75%">COMPROBANTE DE ATENCIÓN DE BENEFICIARIOS DE AGENTES DEL SEGURO DE SALUD</td>
+                <td>FECHA<hr class="styled-hr"></hr><span th:text="${attentionDate}">11/11/2011</span></td>
+            </tr>
+            <tr>
+                <td class="left-aligned-text">Denominación HPdGD<hr class="styled-hr"></hr><span th:text="${institutionName}">Hospital Vera Barros</span></td>
+                <td>Código HPdGPD-REFES<hr class="styled-hr"></hr><span th:text="${institutionSisaCode}">123456789</span></td>
+            </tr>
+        </table>
+        <table class="full-width no-top-border no-bottom-border">
+            <tr class="title no-top-border no-bottom-border" >
+                <td class="no-top-border no-bottom-border">Datos del beneficiario</td>
+            </tr>
+        </table>
+        <table class="full-width no-bottom-border">
+            <tr class="no-bottom-border">
+                <td style="width: 50%;" class="left-aligned-text no-bottom-border">
+                    APELLIDO Y NOMBRE
+                    <hr class="styled-hr"></hr>
+                    <span th:if="${patientName != null}" th:text="${patientName}">Martín Miguel de Güemes</span>
+                    <span th:unless="${patientName != null}" style="color: gray;">Paciente no especificado</span>
+                </td>
+                <td class="left-aligned-text no-bottom-border">
+                    Tipo de documento
+                    <hr class="styled-hr"></hr>
+                    <span th:if="${identificationType != null}" th:text="${identificationType}">DNI</span>
+                    <span th:unless="${identificationType != null}" style="display: inline-block; width: 100%;">&nbsp;</span>
+                </td>
+                <td style="width: 25%;" class="left-aligned-text no-bottom-border">
+                    N° de documento
+                    <hr class="styled-hr"></hr>
+                    <span th:if="${identificationNumber != null}" th:text="${identificationNumber}">123456789</span>
+                    <span th:unless="${identificationNumber != null}" style="display: inline-block; width: 100%;">&nbsp;</span>
+                </td>
+            </tr>
+        </table>
+        <table class="full-width no-top-border">
+            <tr>
+                <td>Tipo de beneficiario</td>
+                <td style="width: 35%;">Parentesco</td>
+                <td style="width: 15%;">Sexo</td>
+                <td style="width: 10%;">Edad</td>
+            </tr>
+            <tr>
+                <td style="text-align: center;">
+                    <span style="display: inline-block; width: 55px; text-align: center;">Titular</span>
+                    <span style="display: inline-block; width: 55px; text-align: center;">Familiar</span>
+                    <span style="display: inline-block; width: 55px; text-align: center;">Adherente</span>
+                    <span style="display: inline-block; width: 55px; text-align: center;">Otro</span>
+                </td>
+                <td style="width: 35%;">
+                    <span style="display: inline-block; width: 60px; text-align: center;">Cónyuge</span>
+                    <span style="display: inline-block; width: 60px; text-align: center;">Hijo/a</span>
+                    <span style="display: inline-block; width: 60px; text-align: center;">Otro</span>
+                </td>
+                <td style="width: 15%;"><span th:text="${gender}">Masculino</span></td>
+                <td style="width: 10%;"><span th:text="${patientAge}">69</span></td>
+            </tr>
+        </table>
+        <table class="full-width no-top-border no-bottom-border">
+            <tr class="title no-top-border no-bottom-border">
+                <td class="no-top-border no-bottom-border">⠀</td> <!-- Caracter invisible -->
+            </tr>
+        </table>
+        <table class="full-width no-bottom-border">
+            <tr class="no-bottom-border">
+                <td class="no-bottom-border" style="width: 75%;">TIPO DE ATENCIÓN</td>
+                <td class="no-bottom-border">Fecha de prestación<hr class="styled-hr"></hr><span th:text="${attentionDate}">11/11/2011</span></td>
+            </tr>
+        </table>
+        <table class="full-width no-bottom-border">
+            <tr class="no-bottom-border">
+                <td class="no-bottom-border left-aligned-text" style="width: 25%;">CONSULTA</td>
+                <td style="width: 5%;" class="no-bottom-border"></td>
+                <td class="no-bottom-border left-aligned-text">
+                    ESPECIALIDAD
+                    <hr class="styled-hr"></hr>
+                    <span th:if="${clinicalSpecialty != null}" th:text="${clinicalSpecialty}">Urólogo</span>
+                    <span th:unless="${clinicalSpecialty != null}" style="display: inline-block; width: 100%;">&nbsp;</span>
+                </td>
+                <td class="no-bottom-border left-aligned-text">DIAGNÓSTICOS
+                    <hr class="styled-hr"></hr>
+                    <span th:if="${diagnosis != null}" th:text="${diagnosis}">Fallo de riñón</span>
+                    <span th:unless="${diagnosis != null}" style="display: inline-block; width: 100%;">&nbsp;</span>
+                </td>
+            </tr>
+        </table>
+        <table class="full-width no-bottom-border">
+            <tr class="no-bottom-border">
+                <td class="no-bottom-border left-aligned-text" style="width: 25%;">PRÁCTICA</td>
+                <td style="width: 5%;" class="no-bottom-border"></td>
+                <td class="no-bottom-border left-aligned-text">Códigos NHPdGD:</td>
+            </tr>
+        </table>
+        <table class="full-width no-bottom-border">
+            <tr class="no-bottom-border">
+                <td class="no-bottom-border left-aligned-text" style="width: 25%;">INTERNACIÓN</td>
+                <td style="width: 5%;" class="no-bottom-border"></td>
+                <td class="no-bottom-border left-aligned-text">Diagnóstico de egreso CIE-10<br></br>&nbsp;<br></br></td>
+                <td class="no-bottom-border left-aligned-text">CÓDIGO PRINCIPAL:<br></br>&nbsp;<br></br></td>
+                <td class="no-bottom-border left-aligned-text">OTROS CÓDIGOS:<br></br>&nbsp;<br></br></td>
+            </tr>
+        </table>
+        <table class="full-width no-bottom-border">
+            <tr class="no-bottom-border">
+                <td class="no-bottom-border left-aligned-text">NHPdGD: Nomenclador Hospitales Públicos de Gestión Descentralizada - CIE-10: Clasificación Internacional de Enfermedades</td>
+            </tr>
+        </table>
+        <table class="full-width no-bottom-border">
+            <tr class="no-bottom-border" style="height: 150px; vertical-align: top;">
+                <td class="no-bottom-border">Firma del médico y sello con n° de matrícula</td>
+                <td class="no-bottom-border">Último recibo de sueldo</td>
+                <td style="width: 13%;" class="no-bottom-border">MES<hr class="styled-hr"></hr></td>
+                <td style="width: 12%;" class="no-bottom-border">AÑO<hr class="styled-hr"></hr></td>
+            </tr>
+        </table>
+        <table class="full-width no-bottom-border">
+            <tr class="title">
+                <td style="width: 75%;" class="no-bottom-border">NOMBRE DE AGENTE DEL SEGURO DE SALUD</td>
+                <td class="no-bottom-border">RNOS</td>
+            </tr>
+            <tr class="no-bottom-border">
+                <td class="no-bottom-border">
+                    <span th:if="${medicalCoverageName != null}" th:text="${medicalCoverageName}">OSDE</span>
+                    <span th:unless="${medicalCoverageName != null}" style="color: gray;">Sin cobertura médica, añadir si correspondiese</span>
+                </td>
+                <td class="no-bottom-border"><span th:text="${medicalCoverageRnos}">123456789</span></td>
+            </tr>
+        </table>
+        <table class="full-width">
+            <tr style="height: 150px; vertical-align: top;">
+                <td style="width: 34%;">Firma del responsable administrativo/contable<hr class="styled-hr"></hr></td>
+                <td style="width: 33%;">Aclaración de firma<hr class="styled-hr"></hr></td>
+                <td>Firma del beneficiario<hr class="styled-hr"></hr></td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
# Annex in emergency care ("guardia")

### Changes

What this PR does:

- Adds an endpoint to download **annex** document with data from `emergency_care_episode` and related tables
- Creates an HTML replica of the original **annex** document, with placeholders for nullable values

### Testing

- Manual controller endpoint testing performed using Swagger UI

### Endpoint information

#### URL

- `/institution/{institutionId}/emergency-care/episodes/{episodeId}/annex-pdf` - **GET**

#### Path parameters

- `institutionId` - integer
- `episodeId` - integer

#### Header(s)

- `Authorization`

#### Example request

```bash
curl -X 'GET' \
  'http://localhost:8080/api/institution/1/emergency-care/episodes/1/annex-pdf' \
  -H 'accept: */*' \
  -H 'Authorization: Bearer [token]'
```

#### Response

- Downloads a **PDF** file with the name "**Anexo II - Guardia - ID [episodeId]**"

### Technical information

- The data (if non-null) that populates the HTML template is the following:
   - institutionName
   - institutionSisaCode
   - patientName
   - identificationNumber
   - identificationType
   - gender
   - patientAge
   - attentionDate
   - diagnosis
   - medicalCoverageName
   - medicalCoverageRnos